### PR TITLE
Study question visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,6 @@
 .study-question-callout {
     border-left: 4px solid #007BFF; /* Change color as needed */
     padding: 10px;
-    background-color: #f9f9f9;
     margin-bottom: 20px;
 }
 .study-question-callout::before {


### PR DESCRIPTION
Study questions were invisible during dark mode since the background was set to white, and the text on top would change to white in dark mode, so I changed the background of study questions to transparent:

original light mode 
![image](https://github.com/user-attachments/assets/61278bf6-9f7a-49c1-a3ee-f6e95751b6b5)

original dark mode
![image](https://github.com/user-attachments/assets/fe9b6276-bc09-4fd1-9803-2d9fbdc55441)

new light mode
![image](https://github.com/user-attachments/assets/d30666fe-851e-413e-a3e8-3bc580dd3372)

new dark mode
![image](https://github.com/user-attachments/assets/5abe3d41-b42c-4c8a-ad2e-ecfecbf6f425)

