### PR TITLE
RL chapter: clean up DQN/fitted-Q exposition and apply NOTATION.md Q conventions

### DIFF
--- a/reinforcement_learning.qmd
+++ b/reinforcement_learning.qmd
@@ -404,7 +404,7 @@ data).
 Note that fitted-Q and the experience-replay version of online Q-learning above are not so much rival algorithms as two points on a spectrum: both store past transitions and both fit a network to bootstrapped Bellman targets. They differ in *how often* the targets get refreshed (every gradient step vs. once per outer iteration) and in *how many* gradient steps are taken between refreshes.
 
 ## Policy gradient {#sec-rl_policy_search}
-
+OLD: 
 A different model-free strategy is to search directly for a good policy. The strategy here is to define a functional form $f(s;\theta) = a$ for the policy, where $\theta$ represents the parameters we learn from experience. We choose $f$ to be differentiable, and often define 
 
 :::{.column-margin}
@@ -419,6 +419,21 @@ Now, we can train the policy parameters using gradient descent:
 - When $\theta$ has higher dimensions (e.g., it represents the set of parameters in a complicated neural network), there are more clever algorithms, e.g., one called *REINFORCE*, but they can often be difficult to get to work reliably.
 
 Policy search is a good choice when the policy has a simple known form, but the MDP would be much more complicated to estimate.
+
+NEW:
+
+A different model-free strategy is to search directly for a good policy, rather than first estimating a value function or transition model. The idea is to choose a parameterized family of policies
+$\pi_\theta(a \mid s)$,
+where $\theta$ denotes the parameters to be learned from experience. In most policy-gradient methods, $\pi_\theta(a \mid s)$ is chosen to be differentiable with respect to $\theta$, so that we can improve the policy using gradient-based optimization.
+Here, $\pi_\theta(a \mid s)$ is a conditional probability distribution over actions given the current state. In other words, when the agent is in state $s$, it chooses action $a$ with probability $\pi_\theta(a \mid s)$. Using a stochastic policy like this is often helpful during learning, because it naturally incorporates exploration.
+Our goal is to choose $\theta$ to maximize the expected cumulative reward obtained by following $\pi_\theta$. If $\rho_0$ denotes the initial-state distribution, one natural objective is $J(\theta) = \mathbb{E}\left[\sum_{t=0}^{\infty}\gamma^t R_t \,\middle|\, s_0 \sim \rho_0,\; a_t \sim \pi_\theta(\cdot \mid S_t)\right].$
+We then update the parameters in the direction that increases this objective:
+$\theta \leftarrow \theta + \alpha \nabla_\theta J(\theta)$,
+where $\alpha > 0$ is a step size. This is gradient ascent, since we are trying to maximize reward. Equivalently, one could minimize $-J(\theta)$ using gradient descent.
+When $\theta$ has relatively low dimension, one can estimate the gradient numerically by evaluating the policy at several nearby parameter values and comparing the resulting returns. This is conceptually simple, but it becomes expensive as the number of parameters grows.
+When $\theta$ has high dimension, for example when $\pi_\theta$ is represented by a neural network, it is more common to estimate $\nabla_\theta J(\theta)$ directly from sampled trajectories. One classic method for doing this is REINFORCE. Roughly speaking, REINFORCE increases the probability of actions that led to high return and decreases the probability of actions that led to low return. These methods can work well, but they are often noisy and can be difficult to tune in practice.
+Policy-gradient methods are especially attractive when the policy has a simple useful form, or when the action space is large or continuous and it is awkward to search over actions using a value function. In such cases, it can be easier to learn a policy that outputs actions directly than to learn a Q-function and repeatedly solve
+$\arg\max_a Q(s,a)$.
 
 ## Model-based RL {#sec-rl_model_based}
 
@@ -440,7 +455,7 @@ Conceptually, this is similar to having "initialized" our estimate for the trans
 
 Adding 1 and $|\mathcal{S}|$ to the numerator and denominator, respectively, is a form of smoothing called the *Laplace correction*. It ensures that we never estimate that a probability is 0, and keeps us from dividing by 0. As the amount of data we gather increases, the influence of this correction fades away.
 
-Given our assumption that rewards are deterministic functions of $(s,a)$, a single observed reward is sufficient to determine $R(s,a)$. Our model $\hat{R}$ can simply be a record of observed rewards, such that $\hat{R}(s, a) = r = R(s,a)$.
+Given our assumption that rewards are deterministic functions of $(s,a)$, a single observed reward is sufficient to determine $R(s,a)$. Our model $\hat{R}$ can simply be a record of observed rewards $r$, such that $\hat{R}(s, a) = r = R(s,a)$.
 
 Given empirical models $\hat{T}$ and $\hat{R}$ for the transition and reward functions, we can now solve the MDP $(\mathcal{S}, \mathcal{A}, \hat{T}, \hat{R})$ to find an optimal policy using value iteration, or use a search algorithm to find an action to take for a particular state.
 

--- a/reinforcement_learning.qmd
+++ b/reinforcement_learning.qmd
@@ -304,21 +304,23 @@ Here, we can see the exploration/exploitation dilemma in action: from the perspe
 Determine the Q value functions that result from always executing the “move left” policy.
 :::
 
-## Function approximation: Deep Q learning
+## Q-learning with function approximation
 
 In our Q-learning algorithm above, we essentially keep track of each $Q$ value in a table, indexed by $s$ and $a$. What do we do if $\mathcal{S}$ and/or $\mathcal{A}$ are large (or continuous)?
 
 We can use a function approximator like a neural network to store Q values. For example, we could design a neural network that takes inputs $s$ and $a$, and outputs $Q(s,a)$. We can treat this as a regression problem, optimizing this loss:
 
 $$
-\left(Q(s,a) - (r + \gamma \max_{a'}Q(s',a'))\right)^2
+\mathcal{L}(\theta) \;=\; \bigl(Q_\theta(s,a) \;-\; y\bigr)^2,
+\qquad
+y \;=\; r + \gamma \max_{a'} Q_\theta(s', a')
 $$
 
 :::{.column-margin}
 This is the so-called squared Bellman error; as the name suggests, it's closely related to the Bellman equation we saw in **MDPs** in Chapter @sec-mdps. Roughly speaking, this error measures how much the Bellman equality is violated.
 :::
 
-where $Q(s, a)$ is now the output of the neural network.
+where $Q_\theta(s, a)$ is the output of a neural network with parameters $\theta$. An important subtlety: the target $y$ also depends on $\theta$ (through $Q_\theta(s', a')$), but we treat it as a constant when computing the gradient. The fitted-Q algorithm below makes this explicit by freezing the target as a regression label.
 
 There are several different architectural choices for using a neural network to approximate $Q$ values:
 
@@ -344,12 +346,15 @@ But when a learning agent, such as a robot, is moving through an environment, th
 
 One way to handle this is to use *experience replay*, where we save our $(s,a,s',r)$ experiences in a *replay buffer*. Whenever we take a step in the world, we add the $(s,a,s',r)$ to the replay buffer and use it to do a Q-learning update. Then we also randomly select some number of tuples from the replay buffer, and do Q-learning updates based on them as well. In general, it may help to keep a *sliding window* of just the 1000 most recent experiences in the replay buffer. (A larger buffer will be necessary for situations when the optimal policy might visit a large part of the state space, but we like to keep the buffer size small for memory reasons and also so that we don't focus on parts of the state space that are irrelevant for the optimal policy.) The idea is that it will help us propagate reward values through our state space more efficiently if we do these updates. We can see it as doing something like value iteration, but using samples of experience rather than a known model.
 
+:::{.callout-note}
+## Connection to DQN
+The combination of (i) a neural-network $Q$ approximator, (ii) an experience replay buffer, and (iii) a separate *target network*, is the recipe known as *Deep Q-Networks* (DQN). The target network is a copy of $Q_\theta$ whose parameters are held fixed for many SGD steps and only periodically refreshed from the online network; the targets $y = r + \gamma \max_{a'} Q_{\theta^-}(s', a')$ use those frozen parameters $\theta^-$. Stop-gradient prevents the target from moving *within* a single update; the target network keeps it from drifting *across* many updates. We don't cover target networks in detail here, but they are the third standard ingredient in any DQN implementation.
+:::
 
-
-### Fitted Q-learning
+### Fitted Q-learning {#sec-fitted_q}
 An alternative strategy for learning the $Q$ function that is somewhat
 more robust than the standard $Q$-learning algorithm is a method
-called *fitted Q*.
+called *fitted Q*. It uses the same Bellman-error idea as above, but cleanly separates the two phases: first freeze the bootstrapped targets $y = r + \gamma \max_{a'} Q(s', a')$ into a static dataset, then run ordinary supervised regression to fit $Q$ to those targets.
 
 
 ```pseudocode
@@ -360,8 +365,9 @@ called *fitted Q*.
 #| html-no-end: false
 #| pdf-placement: "htb!"
 #| pdf-line-number: true
-#| label: Q-Learning
+#| label: Fitted-Q-Learning
 
+\begin{algorithm}
 \begin{algorithmic}[1]
   \Procedure{Fitted-Q-Learning}{$\mathcal{A}, s_0, \gamma, \alpha, \epsilon, m$}
     \State $s \gets s_0$ \Comment{e.g., $s_0$ can be drawn randomly from $\mathcal{S}$}
@@ -376,11 +382,11 @@ called *fitted Q*.
         \State $y \gets r + \gamma \max_{a' \in \mathcal{A}} Q(s', a')$
         \State $\mathcal{D}_\text{supervised} \gets \mathcal{D}_\text{supervised} \cup \{(x,y)\}$
       \EndFor
-      \State re-initialize neural-network representation of $Q$
       \State $Q \gets \text{supervised-NN-regression}(\mathcal{D}_\text{supervised})$
     \EndWhile
   \EndProcedure
 \end{algorithmic}
+\end{algorithm}
 ```
 
 
@@ -392,9 +398,11 @@ function on the whole data set.  This method does not mix the
 dynamic-programming phase (computing new $Q$ values based on old ones)
 with the function approximation phase (supervised training of the
 neural network) and avoids catastrophic forgetting.  The regression
-training in line 10 typically uses squared error as a loss function and
+training typically uses squared error as a loss function and
 would be trained until the fit is good (possibly measured on held-out
 data).
+
+Note that fitted-Q and the experience-replay version of online Q-learning above are not so much rival algorithms as two points on a spectrum: both store past transitions and both fit a network to bootstrapped Bellman targets. They differ in *how often* the targets get refreshed (every gradient step vs. once per outer iteration) and in *how many* gradient steps are taken between refreshes.
 
 ## Policy gradient {#sec-rl_policy_search}
 

--- a/reinforcement_learning.qmd
+++ b/reinforcement_learning.qmd
@@ -125,10 +125,7 @@ state space would allow the state to take values from, say, a
 continuous range of numbers; for example, the state could be any real
 number in the interval $[1,3]$. Similarly, a continuous action space
 would allow the action to be drawn from, e.g., a continuous range of
-numbers. There are now many extensions developed based on Q-learning
-that can handle continuous state and action spaces (we'll look at one
-soon), and therefore the algorithm above is also sometimes referred to
-more specifically as tabular Q-learning.
+numbers. There are many Q-learning extensions that handle large or continuous state spaces (we’ll look at one soon); continuous action spaces usually require additional ideas, often from policy-gradient methods or actor-critic methods that are beyond our scope. Therefore, the algorithm above is sometimes referred to more specifically as tabular Q-learning to differentiate it from these extensions.
 
 
 In the Q-learning update rule
@@ -404,36 +401,24 @@ data).
 Note that fitted-Q and the experience-replay version of online Q-learning above are not so much rival algorithms as two points on a spectrum: both store past transitions and both fit a network to bootstrapped Bellman targets. They differ in *how often* the targets get refreshed (every gradient step vs. once per outer iteration) and in *how many* gradient steps are taken between refreshes.
 
 ## Policy gradient {#sec-rl_policy_search}
-OLD: 
-A different model-free strategy is to search directly for a good policy. The strategy here is to define a functional form $f(s;\theta) = a$ for the policy, where $\theta$ represents the parameters we learn from experience. We choose $f$ to be differentiable, and often define 
+A different model-free strategy is to search directly for a good policy, rather than first estimating a value function or transition model. For example, when the action space is large or continuous and it is awkward to search over actions using a value function, it can be easier to learn a policy that outputs actions directly than to learn a Q-function and repeatedly solve
+$\arg\max_a Q(s,a)$. The idea is to choose a parameterized family of policies $\pi_\theta(a \mid s)$, where $\theta$ denotes the parameters to be learned from experience. In most policy-gradient methods, $\pi_\theta(a \mid s)$ is chosen to be differentiable with respect to $\theta$, so that we can improve the policy using gradient-based optimization.
 
-:::{.column-margin}
-This means the chance of choosing an action depends on which state the agent is in. Suppose, e.g., a robot is trying to get to a goal and can go left or right. An unconditional policy can say: I go left 99% of the time; a conditional policy can consider the robot's state, and say: if I'm to the right of the goal, I go left 99% of the time.
-:::
-
-$f(s, a;\theta) = Pr(a|s)$, a conditional probability distribution over our possible actions.
-
-Now, we can train the policy parameters using gradient descent:
-
-- When $\theta$ has relatively low dimension, we can compute a numeric estimate of the gradient by running the policy multiple times for different values of $\theta$, and computing the resulting rewards.
-- When $\theta$ has higher dimensions (e.g., it represents the set of parameters in a complicated neural network), there are more clever algorithms, e.g., one called *REINFORCE*, but they can often be difficult to get to work reliably.
-
-Policy search is a good choice when the policy has a simple known form, but the MDP would be much more complicated to estimate.
-
-NEW:
-
-A different model-free strategy is to search directly for a good policy, rather than first estimating a value function or transition model. The idea is to choose a parameterized family of policies
-$\pi_\theta(a \mid s)$,
-where $\theta$ denotes the parameters to be learned from experience. In most policy-gradient methods, $\pi_\theta(a \mid s)$ is chosen to be differentiable with respect to $\theta$, so that we can improve the policy using gradient-based optimization.
 Here, $\pi_\theta(a \mid s)$ is a conditional probability distribution over actions given the current state. In other words, when the agent is in state $s$, it chooses action $a$ with probability $\pi_\theta(a \mid s)$. Using a stochastic policy like this is often helpful during learning, because it naturally incorporates exploration.
-Our goal is to choose $\theta$ to maximize the expected cumulative reward obtained by following $\pi_\theta$. If $\rho_0$ denotes the initial-state distribution, one natural objective is $J(\theta) = \mathbb{E}\left[\sum_{t=0}^{\infty}\gamma^t R_t \,\middle|\, s_0 \sim \rho_0,\; a_t \sim \pi_\theta(\cdot \mid S_t)\right].$
+
+Our goal is to choose $\theta$ to maximize the expected cumulative reward obtained by following $\pi_\theta$. If $\rho_0$ denotes the initial-state distribution, one natural objective is
+$$
+J(\theta) = \mathbb{E}\left[\sum_{t=0}^{\infty}\gamma^t R_t \,\middle|\, s_0 \sim \rho_0,\; a_t \sim \pi_\theta(\cdot \mid S_t)\right].
+$$
 We then update the parameters in the direction that increases this objective:
-$\theta \leftarrow \theta + \alpha \nabla_\theta J(\theta)$,
+$$
+\theta \leftarrow \theta + \alpha \nabla_\theta J(\theta),
+$$
 where $\alpha > 0$ is a step size. This is gradient ascent, since we are trying to maximize reward. Equivalently, one could minimize $-J(\theta)$ using gradient descent.
+
 When $\theta$ has relatively low dimension, one can estimate the gradient numerically by evaluating the policy at several nearby parameter values and comparing the resulting returns. This is conceptually simple, but it becomes expensive as the number of parameters grows.
+
 When $\theta$ has high dimension, for example when $\pi_\theta$ is represented by a neural network, it is more common to estimate $\nabla_\theta J(\theta)$ directly from sampled trajectories. One classic method for doing this is REINFORCE. Roughly speaking, REINFORCE increases the probability of actions that led to high return and decreases the probability of actions that led to low return. These methods can work well, but they are often noisy and can be difficult to tune in practice.
-Policy-gradient methods are especially attractive when the policy has a simple useful form, or when the action space is large or continuous and it is awkward to search over actions using a value function. In such cases, it can be easier to learn a policy that outputs actions directly than to learn a Q-function and repeatedly solve
-$\arg\max_a Q(s,a)$.
 
 ## Model-based RL {#sec-rl_model_based}
 

--- a/reinforcement_learning.qmd
+++ b/reinforcement_learning.qmd
@@ -55,22 +55,22 @@ Model-free methods are methods that do not explicitly learn transition and rewar
 
 ### Q-learning {#sec-q_learning}
 
-Q-learning is a frequently used class of RL algorithms that concentrates on learning (estimating) the state-action value function, i.e., the $Q$ function. Specifically, recall the MDP value-iteration update:
+Q-learning is a frequently used class of RL algorithms that concentrates on learning (estimating) the state-action value function, i.e., the $\mathrm{Q}$ function. Specifically, recall the MDP value-iteration update:
 
 
 
 $$
 \begin{equation}
-  Q(s,a) = R(s,a) + \gamma \sum_{s'} T(s,a,s')\max_{a'}Q(s',a')
+  \mathrm{Q}(s,a) = \mathrm{R}(s,a) + \gamma \sum_{s'} \mathrm{T}(s,a,s')\max_{a'}\mathrm{Q}(s',a')
 \end{equation}
 $$
 
 ::: {.column-margin}
-The thing that most students seem to get confused about is when we do value iteration and when we do Q-learning. Value iteration assumes you know $T$ and $R$ and just need to _compute_ $Q$. In Q-learning, we don't know or even directly estimate $T$ and $R$: we estimate $Q$ directly from experience!
+The thing that most students seem to get confused about is when we do value iteration and when we do Q-learning. Value iteration assumes you know $\mathrm{T}$ and $\mathrm{R}$ and just need to _compute_ $\mathrm{Q}$. In Q-learning, we don't know or even directly estimate $\mathrm{T}$ and $\mathrm{R}$: we estimate $\mathrm{Q}$ directly from experience!
 :::
 
-The Q-learning algorithm below adapts this value-iteration idea to the RL scenario, where we do not know the transition function $T$ or
-reward function $R$, and instead rely on samples to perform the updates.
+The Q-learning algorithm below adapts this value-iteration idea to the RL scenario, where we do not know the transition function $\mathrm{T}$ or
+reward function $\mathrm{R}$, and instead rely on samples to perform the updates.
 
 
 ```pseudocode
@@ -88,18 +88,18 @@ reward function $R$, and instead rely on samples to perform the updates.
 \Procedure{Q-Learning}{$\mathcal{S}, \mathcal{A}, \gamma, \alpha, s_0, \text{max\_iter}$}
   \State $i \gets 0$
   \ForAll{$s \in \mathcal{S},\; a \in \mathcal{A}$}
-    \State $Q_{\text{old}}(s, a) \gets 0$
+    \State $\mathrm{Q}_{\text{old}}(s, a) \gets 0$
   \EndFor
   \State $s \gets s_0$
   \While{$i < \text{max\_iter}$}
-    \State $a \gets \text{select\_action}\bigl(s,\,Q_{\text{old}}(s,a)\bigr)$
+    \State $a \gets \text{select\_action}\bigl(s,\,\mathrm{Q}_{\text{old}}(s,a)\bigr)$
     \State $(r, s') \gets \text{execute}(a)$
-    \State $Q_{\text{new}}(s, a) \gets (1-\alpha)\,Q_{\text{old}}(s,a)\;+\;\alpha\bigl(r + \gamma \max_{a'}Q_{\text{old}}(s',a')\bigr)$
+    \State $\mathrm{Q}_{\text{new}}(s, a) \gets (1-\alpha)\,\mathrm{Q}_{\text{old}}(s,a)\;+\;\alpha\bigl(r + \gamma \max_{a'}\mathrm{Q}_{\text{old}}(s',a')\bigr)$
     \State $s \gets s'$
     \State $i \gets i + 1$
-    \State $Q_{\text{old}} \gets Q_{\text{new}}$
+    \State $\mathrm{Q}_{\text{old}} \gets \mathrm{Q}_{\text{new}}$
   \EndWhile
-  \Return $Q_{\text{new}}$
+  \Return $\mathrm{Q}_{\text{new}}$
 \EndProcedure
 \end{algorithmic}
 \end{algorithm}
@@ -135,12 +135,12 @@ In the Q-learning update rule
 
 $$
 \begin{equation}\label{q_avg}
-  Q[s, a] \leftarrow (1-\alpha)Q[s, a]
-  + \alpha(r + \gamma \max_{a'}Q[s',a'])
+  \mathrm{Q}[s, a] \leftarrow (1-\alpha)\mathrm{Q}[s, a]
+  + \alpha(r + \gamma \max_{a'}\mathrm{Q}[s',a'])
 \end{equation}
 $${#eq-q-avg}
 
-the term $(r + \gamma \max_{a'}Q[s',a'])$ is often referred to as the one-step look-ahead *target*. The update can be viewed as a
+the term $(r + \gamma \max_{a'}\mathrm{Q}[s',a'])$ is often referred to as the one-step look-ahead *target*. The update can be viewed as a
 combination of two different iterative processes that we have already
 seen: the combination of an old estimate with the target using a
 running average with a learning rate $\alpha.$
@@ -150,34 +150,34 @@ running average with a learning rate $\alpha.$
 
 $$
 \begin{equation}\label{td:q}
-  Q[s, a] \leftarrow Q[s, a]
-  + \alpha\bigl((r + \gamma \max_{a'} Q[s',a'])-Q[s,a]\bigr),
+  \mathrm{Q}[s, a] \leftarrow \mathrm{Q}[s, a]
+  + \alpha\bigl((r + \gamma \max_{a'} \mathrm{Q}[s',a'])-\mathrm{Q}[s,a]\bigr),
 \end{equation}
 $${#eq-td-q}
 
-which allows us to interpret Q-learning in yet another way: we make an update (or correction) based on the temporal difference between the target and the current estimated value $Q[s, a].$
+which allows us to interpret Q-learning in yet another way: we make an update (or correction) based on the temporal difference between the target and the current estimated value $\mathrm{Q}[s, a].$
 
 
 
-The Q-learning algorithm above includes a procedure called `select_action`, that, given the current state $s$ and current $Q$ function, has to decide
-which action to take.  If the $Q$ value is estimated very accurately
+The Q-learning algorithm above includes a procedure called `select_action`, that, given the current state $s$ and current $\mathrm{Q}$ function, has to decide
+which action to take.  If the $\mathrm{Q}$ value is estimated very accurately
 and the agent is deployed to "behave" in the world (as opposed to "learn" in the world),  then generally we would want
-to choose the apparently optimal action $\arg\max_{a \in \mathcal{A}} Q(s,a)$.
+to choose the apparently optimal action $\arg\max_{a \in \mathcal{A}} \mathrm{Q}(s,a)$.
 
-But, during learning, the $Q$ value estimates won't be very
+But, during learning, the $\mathrm{Q}$ value estimates won't be very
 good and exploration is important.  However, exploring completely at random is also usually not the best strategy while learning, because it is good to focus your attention on the parts of the state space
 that are likely to be visited when executing a good policy (not a bad or random one).
 
 A typical action-selection strategy that attempts to address this *exploration versus exploitation* dilemma is the so-called *$\epsilon$-greedy* strategy:
 
-- with probability $1-\epsilon$, choose $\arg\max_{a \in \mathcal{A}} Q(s,a)$;
+- with probability $1-\epsilon$, choose $\arg\max_{a \in \mathcal{A}} \mathrm{Q}(s,a)$;
 
 - with probability $\epsilon$, choose the action $a \in \mathcal{A}$ uniformly at random.
 
 where the $\epsilon$ probability of choosing a random action helps the agent to explore and try out actions that might not seem so desirable at the moment.
 
 Q-learning has the surprising property that it is *guaranteed* to
-converge to the actual optimal $Q$ function! The conditions specified in the theorem are: visit every state-action pair infinitely often, and the learning rate $\alpha$ satisfies a scheduling condition. This implies that for exploration strategy specifically, any strategy is okay as long as it tries every state-action infinitely often on an infinite run (so that it doesn't converge prematurely to a bad action choice).
+converge to the actual optimal $\mathrm{Q}$ function! The conditions specified in the theorem are: visit every state-action pair infinitely often, and the learning rate $\alpha$ satisfies a scheduling condition. This implies that for exploration strategy specifically, any strategy is okay as long as it tries every state-action infinitely often on an infinite run (so that it doesn't converge prematurely to a bad action choice).
 
 Q-learning can be very inefficient. Imagine a robot that has a
 choice between moving to the left and getting a reward of 1, then
@@ -214,36 +214,36 @@ Q-learning is guaranteed to converge to the optimal Q function under weak condit
 :::
 
 The first time the robot moves to the right and goes down the hallway,
-it will update the $Q$ value just for state 9 on the hallway and
+it will update the $\mathrm{Q}$ value just for state 9 on the hallway and
 action ``right'' to have a high value, but it won't yet understand
 that moving to the right in the earlier steps was a good choice. The
 next time it moves down the hallway it updates the value of the state before the last one, and so on.  After 10 trips down the hallway, it now can see that it is better to move to the right than to the left.
 
-More concretely, consider the vector of Q values $Q(i = 0, \ldots, 9; \text{right})$, representing the Q values for moving right at each of the positions $i = 0, \ldots, 9$. Position index 0 is the starting position of the robot as pictured above.
+More concretely, consider the vector of Q values $\mathrm{Q}(i = 0, \ldots, 9; \text{right})$, representing the Q values for moving right at each of the positions $i = 0, \ldots, 9$. Position index 0 is the starting position of the robot as pictured above.
 
 Then, for $\alpha = 1$ and $\gamma = 0.9$, @eq-td-q becomes
 
 $$
-Q(i, \text{right}) \;=\; R(i, \text{right}) \;+\; 0.9 \,\max_a Q(i+1, a)\,.
+\mathrm{Q}(i, \text{right}) \;=\; \mathrm{R}(i, \text{right}) \;+\; 0.9 \,\max_a \mathrm{Q}(i+1, a)\,.
 $$
 
 Starting with Q values of 0,
 
 $$
-Q^{(0)}(i = 0, \ldots, 9;\,\text{right})
+\mathrm{Q}^{(0)}(i = 0, \ldots, 9;\,\text{right})
 =\begin{bmatrix}
 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0
 \end{bmatrix}\,.
 $$
 
 ::: {.column-margin}
-We are violating our usual notational conventions here, and writing ${Q}^{i}$ to mean the Q value function that results after the robot runs all the way to the end of the hallway, when executing the policy that always moves to the right.
+We are violating our usual notational conventions here, and writing $\mathrm{Q}^{i}$ to mean the Q value function that results after the robot runs all the way to the end of the hallway, when executing the policy that always moves to the right.
 :::
 
-Since the only nonzero reward from moving right is $R(9,\text{right}) = 1000$, after our robot makes it down the hallway once, our new Q vector is
+Since the only nonzero reward from moving right is $\mathrm{R}(9,\text{right}) = 1000$, after our robot makes it down the hallway once, our new Q vector is
 
 $$
-Q^{(1)}(i = 0, \ldots, 9;\,\text{right})
+\mathrm{Q}^{(1)}(i = 0, \ldots, 9;\,\text{right})
 =\begin{bmatrix}
 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 1000
 \end{bmatrix}\,.
@@ -252,13 +252,13 @@ $$
 After making its way down the hallway again,
 
 $$
-Q(8,\text{right}) = 0 + 0.9\,Q(9,\text{right}) = 900
+\mathrm{Q}(8,\text{right}) = 0 + 0.9\,\mathrm{Q}(9,\text{right}) = 900
 $$
 
 updates:
 
 $$
-Q^{(2)}(i = 0, \ldots, 9;\,\text{right})
+\mathrm{Q}^{(2)}(i = 0, \ldots, 9;\,\text{right})
 =\begin{bmatrix}
 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 900 & 1000
 \end{bmatrix}\,.
@@ -267,14 +267,14 @@ $$
 Similarly,
 
 $$
-Q^{(3)}(i = 0, \ldots, 9;\,\text{right})
+\mathrm{Q}^{(3)}(i = 0, \ldots, 9;\,\text{right})
 =\begin{bmatrix}
 0 & 0 & 0 & 0 & 0 & 0 & 0 & 810 & 900 & 1000
 \end{bmatrix}\,,
 $$
 
 $$
-Q^{(4)}(i = 0, \ldots, 9;\,\text{right})
+\mathrm{Q}^{(4)}(i = 0, \ldots, 9;\,\text{right})
 =\begin{bmatrix}
 0 & 0 & 0 & 0 & 0 & 0 & 729 & 810 & 900 & 1000
 \end{bmatrix}\,,
@@ -285,7 +285,7 @@ $$
 $$
 
 $$
-Q^{(10)}(i = 0, \ldots, 9;\,\text{right})
+\mathrm{Q}^{(10)}(i = 0, \ldots, 9;\,\text{right})
 =\\
 \begin{bmatrix}
 387.4 & 420.5 & 478.3 & 531.4 & 590.5 & 656.1 & 729 & 810 & 900 & 1000
@@ -306,9 +306,9 @@ Determine the Q value functions that result from always executing the “move le
 
 ## Q-learning with function approximation
 
-In our Q-learning algorithm above, we essentially keep track of each $Q$ value in a table, indexed by $s$ and $a$. What do we do if $\mathcal{S}$ and/or $\mathcal{A}$ are large (or continuous)?
+In our Q-learning algorithm above, we essentially keep track of each $\mathrm{Q}$ value in a table, indexed by $s$ and $a$. What do we do if $\mathcal{S}$ and/or $\mathcal{A}$ are large (or continuous)?
 
-We can use a function approximator like a neural network to store Q values. For example, we could design a neural network that takes inputs $s$ and $a$, and outputs $Q(s,a)$. We can treat this as a regression problem, optimizing this loss:
+We can use a function approximator like a neural network to store Q values. For example, we could design a neural network with parameters $\theta$ that takes inputs $s$ and $a$, and outputs $Q_\theta(s,a)$. We can treat this as a regression problem, optimizing this loss:
 
 $$
 \mathcal{L}(\theta) \;=\; \bigl(Q_\theta(s,a) \;-\; y\bigr)^2,
@@ -320,19 +320,19 @@ $$
 This is the so-called squared Bellman error; as the name suggests, it's closely related to the Bellman equation we saw in **MDPs** in Chapter @sec-mdps. Roughly speaking, this error measures how much the Bellman equality is violated.
 :::
 
-where $Q_\theta(s, a)$ is the output of a neural network with parameters $\theta$. An important subtlety: the target $y$ also depends on $\theta$ (through $Q_\theta(s', a')$), but we treat it as a constant when computing the gradient. The fitted-Q algorithm below makes this explicit by freezing the target as a regression label.
+An important subtlety: the target $y$ also depends on $\theta$ (through $Q_\theta(s', a')$), but we treat it as a constant when computing the gradient. The fitted-Q algorithm below makes this explicit by freezing the target as a regression label.
 
-There are several different architectural choices for using a neural network to approximate $Q$ values:
+There are several different architectural choices for using a neural network to approximate $\mathrm{Q}$ values:
 
-- One network for each action $a$, that takes $s$ as input and produces $Q(s, a)$ as output;
-- One single network that takes $s$ as input and produces a vector $Q(s, \cdot)$, consisting of the $Q$ values for each action; or
-- One single network that takes $s, a$ concatenated into a vector (if $a$ is discrete, we would probably use a one-hot encoding, unless it had some useful internal structure) and produces $Q(s, a)$ as output.
+- One network for each action $a$, that takes $s$ as input and produces $Q_\theta(s, a)$ as output;
+- One single network that takes $s$ as input and produces a vector $Q_\theta(s, \cdot)$, consisting of the $\mathrm{Q}$ values for each action; or
+- One single network that takes $s, a$ concatenated into a vector (if $a$ is discrete, we would probably use a one-hot encoding, unless it had some useful internal structure) and produces $Q_\theta(s, a)$ as output.
 
 :::{.column-margin}
 For continuous action spaces, it is popular to use a class of methods called *actor-critic methods*, which combine policy and value-function learning. We won't get into them in detail here, though.
 :::
 
-The first two choices are only suitable for discrete (and not too big) action sets. The last choice can be applied for continuous actions, but then it is difficult to find $\arg\max_{a \in \mathcal{A}} Q(s, a)$.
+The first two choices are only suitable for discrete (and not too big) action sets. The last choice can be applied for continuous actions, but then it is difficult to find $\arg\max_{a \in \mathcal{A}} Q_\theta(s, a)$.
 
 There are not many theoretical guarantees about Q-learning with function approximation and, indeed, it can sometimes be fairly unstable (learning to perform well for a while, and then suddenly getting worse, for example). But neural network Q-learning has also had some significant successes.
 
@@ -342,19 +342,19 @@ One form of instability that we do know how to guard against is *catastrophic fo
 And, in fact, we routinely shuffle their order in the data file, anyway.
 :::
 
-But when a learning agent, such as a robot, is moving through an environment, the sequence of states it encounters will be temporally correlated. For example, the robot might spend 12 hours in a dark environment and then 12 in a light one. This can mean that while it is in the dark, the neural-network weight-updates will make the $Q$ function \"forget\" the value function for when it's light.
+But when a learning agent, such as a robot, is moving through an environment, the sequence of states it encounters will be temporally correlated. For example, the robot might spend 12 hours in a dark environment and then 12 in a light one. This can mean that while it is in the dark, the neural-network weight-updates will make $Q_\theta$ \"forget\" the value function for when it's light.
 
 One way to handle this is to use *experience replay*, where we save our $(s,a,s',r)$ experiences in a *replay buffer*. Whenever we take a step in the world, we add the $(s,a,s',r)$ to the replay buffer and use it to do a Q-learning update. Then we also randomly select some number of tuples from the replay buffer, and do Q-learning updates based on them as well. In general, it may help to keep a *sliding window* of just the 1000 most recent experiences in the replay buffer. (A larger buffer will be necessary for situations when the optimal policy might visit a large part of the state space, but we like to keep the buffer size small for memory reasons and also so that we don't focus on parts of the state space that are irrelevant for the optimal policy.) The idea is that it will help us propagate reward values through our state space more efficiently if we do these updates. We can see it as doing something like value iteration, but using samples of experience rather than a known model.
 
 :::{.callout-note}
 ## Connection to DQN
-The combination of (i) a neural-network $Q$ approximator, (ii) an experience replay buffer, and (iii) a separate *target network*, is the recipe known as *Deep Q-Networks* (DQN). The target network is a copy of $Q_\theta$ whose parameters are held fixed for many SGD steps and only periodically refreshed from the online network; the targets $y = r + \gamma \max_{a'} Q_{\theta^-}(s', a')$ use those frozen parameters $\theta^-$. Stop-gradient prevents the target from moving *within* a single update; the target network keeps it from drifting *across* many updates. We don't cover target networks in detail here, but they are the third standard ingredient in any DQN implementation.
+The combination of (i) a neural-network $\mathrm{Q}$ approximator, (ii) an experience replay buffer, and (iii) a separate *target network*, is the recipe known as *Deep Q-Networks* (DQN). The target network is a copy of $Q_\theta$ whose parameters are held fixed for many SGD steps and only periodically refreshed from the online network; the targets $y = r + \gamma \max_{a'} Q_{\theta^-}(s', a')$ use those frozen parameters $\theta^-$. Stop-gradient prevents the target from moving *within* a single update; the target network keeps it from drifting *across* many updates. We don't cover target networks in detail here, but they are the third standard ingredient in any DQN implementation.
 :::
 
 ### Fitted Q-learning {#sec-fitted_q}
-An alternative strategy for learning the $Q$ function that is somewhat
-more robust than the standard $Q$-learning algorithm is a method
-called *fitted Q*. It uses the same Bellman-error idea as above, but cleanly separates the two phases: first freeze the bootstrapped targets $y = r + \gamma \max_{a'} Q(s', a')$ into a static dataset, then run ordinary supervised regression to fit $Q$ to those targets.
+An alternative strategy for learning the $\mathrm{Q}$ function that is somewhat
+more robust than the standard Q-learning algorithm is a method
+called *fitted Q*. It uses the same Bellman-error idea as above, but cleanly separates the two phases: first freeze the bootstrapped targets $y = r + \gamma \max_{a'} Q_\theta(s', a')$ into a static dataset, then run ordinary supervised regression to fit $Q_\theta$ to those targets.
 
 
 ```pseudocode
@@ -390,12 +390,12 @@ called *fitted Q*. It uses the same Bellman-error idea as above, but cleanly sep
 ```
 
 
-Here, we alternate between using the policy induced by the current $Q$
-function to gather a batch of data $\mathcal{D}_\text{new}$, adding it
+Here, we alternate between using the policy induced by the current $Q_\theta$
+to gather a batch of data $\mathcal{D}_\text{new}$, adding it
 to our overall data set $\mathcal{D}$, and then using supervised
-neural-network training to learn a representation of the $Q$ value
+neural-network training to learn a representation of the $\mathrm{Q}$ value
 function on the whole data set.  This method does not mix the
-dynamic-programming phase (computing new $Q$ values based on old ones)
+dynamic-programming phase (computing new $\mathrm{Q}$ values based on old ones)
 with the function approximation phase (supervised training of the
 neural network) and avoids catastrophic forgetting.  The regression
 training typically uses squared error as a loss function and

--- a/reinforcement_learning.qmd
+++ b/reinforcement_learning.qmd
@@ -313,10 +313,8 @@ y \;=\; r + \gamma \max_{a'} Q_\theta(s', a')
 $$
 
 :::{.column-margin}
-This is the so-called squared Bellman error; as the name suggests, it's closely related to the Bellman equation we saw in **MDPs** in Chapter @sec-mdps. Roughly speaking, this error measures how much the Bellman equality is violated.
+This is the so-called squared Bellman error; as the name suggests, it's closely related to the Bellman equation we saw in **MDPs** in @sec-mdps. Roughly speaking, this error measures how much the Bellman equality is violated.
 :::
-
-An important subtlety: the target $y$ also depends on $\theta$ (through $Q_\theta(s', a')$), but we treat it as a constant when computing the gradient. The fitted-Q algorithm below makes this explicit by freezing the target as a regression label.
 
 There are several different architectural choices for using a neural network to approximate $\mathrm{Q}$ values:
 
@@ -341,11 +339,6 @@ And, in fact, we routinely shuffle their order in the data file, anyway.
 But when a learning agent, such as a robot, is moving through an environment, the sequence of states it encounters will be temporally correlated. For example, the robot might spend 12 hours in a dark environment and then 12 in a light one. This can mean that while it is in the dark, the neural-network weight-updates will make $Q_\theta$ \"forget\" the value function for when it's light.
 
 One way to handle this is to use *experience replay*, where we save our $(s,a,s',r)$ experiences in a *replay buffer*. Whenever we take a step in the world, we add the $(s,a,s',r)$ to the replay buffer and use it to do a Q-learning update. Then we also randomly select some number of tuples from the replay buffer, and do Q-learning updates based on them as well. In general, it may help to keep a *sliding window* of just the 1000 most recent experiences in the replay buffer. (A larger buffer will be necessary for situations when the optimal policy might visit a large part of the state space, but we like to keep the buffer size small for memory reasons and also so that we don't focus on parts of the state space that are irrelevant for the optimal policy.) The idea is that it will help us propagate reward values through our state space more efficiently if we do these updates. We can see it as doing something like value iteration, but using samples of experience rather than a known model.
-
-:::{.callout-note}
-## Connection to DQN
-The combination of (i) a neural-network $\mathrm{Q}$ approximator, (ii) an experience replay buffer, and (iii) a separate *target network*, is the recipe known as *Deep Q-Networks* (DQN). The target network is a copy of $Q_\theta$ whose parameters are held fixed for many SGD steps and only periodically refreshed from the online network; the targets $y = r + \gamma \max_{a'} Q_{\theta^-}(s', a')$ use those frozen parameters $\theta^-$. Stop-gradient prevents the target from moving *within* a single update; the target network keeps it from drifting *across* many updates. We don't cover target networks in detail here, but they are the third standard ingredient in any DQN implementation.
-:::
 
 ### Fitted Q-learning {#sec-fitted_q}
 An alternative strategy for learning the $\mathrm{Q}$ function that is somewhat
@@ -398,7 +391,7 @@ training typically uses squared error as a loss function and
 would be trained until the fit is good (possibly measured on held-out
 data).
 
-Note that fitted-Q and the experience-replay version of online Q-learning above are not so much rival algorithms as two points on a spectrum: both store past transitions and both fit a network to bootstrapped Bellman targets. They differ in *how often* the targets get refreshed (every gradient step vs. once per outer iteration) and in *how many* gradient steps are taken between refreshes.
+Note that fitted-Q and the experience-replay version of Q-learning above are not so much rival algorithms as two points on a spectrum: both store past transitions and both fit a network to bootstrapped Bellman targets. They differ in *how often* the targets get refreshed (every gradient step vs. once per outer iteration) and in *how many* gradient steps are taken between refreshes.
 
 ## Policy gradient {#sec-rl_policy_search}
 A different model-free strategy is to search directly for a good policy, rather than first estimating a value function or transition model. For example, when the action space is large or continuous and it is awkward to search over actions using a value function, it can be easier to learn a policy that outputs actions directly than to learn a Q-function and repeatedly solve

--- a/reinforcement_learning.qmd
+++ b/reinforcement_learning.qmd
@@ -47,7 +47,7 @@ Similar to MDP @sec-mdps, in an RL problem, the agent's goal is to learn a *poli
 
 <!-- Most of the focus is on the first criterion (which is called “sample efficiency”), because the second one is very difficult. The first criterion is reasonable when the learning can take place somewhere safe (imagine a robot learning, inside the robot factory, where it can’t hurt itself too badly) or in a simulated environment. -->
 
-Approaches to reinforcement learning differ significantly according to what kind of hypothesis or model is being learned. Roughly speaking, RL methods can be categorized into model-free methods and model-based methods. The main distinction is that model-based methods explicitly learn the transition and reward models to assist the end-goal of learning a policy; model-free methods do not. We will start our discussion with the model-free methods, and introduce two of the arguably most popular types of algorithms, Q-learning @sec-q_learning and policy gradient @sec-rl_policy_search. We then describe model-based methods @sec-rl_model_based. Finally, we briefly consider "bandit" problems @sec-bandit, which differ from our MDP learning context by having probabilistic rewards.
+Approaches to reinforcement learning differ significantly according to what kind of hypothesis or model is being learned. Roughly speaking, RL methods can be categorized into model-free methods and model-based methods. The main distinction is that model-based methods explicitly learn the transition and reward models to assist the end-goal of learning a policy; model-free methods do not. We will start our discussion with the model-free methods, and introduce two of the arguably most popular types of algorithms, Q-learning @sec-q_learning and policy gradient @sec-rl_policy_search. We then describe model-based methods @sec-rl_model_based. Finally, we briefly consider "bandit" problems @sec-bandit, which can be viewed as a simplified RL setting with no state transitions (or a trivial one-state MDP), where the main issue is exploration versus exploitation across actions.
 
 ### Model-free methods
 
@@ -92,7 +92,7 @@ reward function $\mathrm{R}$, and instead rely on samples to perform the updates
   \EndFor
   \State $s \gets s_0$
   \While{$i < \text{max\_iter}$}
-    \State $a \gets \text{select\_action}\bigl(s,\,\mathrm{Q}_{\text{old}}(s,a)\bigr)$
+    \State $a \gets \text{select\_action}\bigl(s,\,\mathrm{Q}_{\text{old}}\bigr)$
     \State $(r, s') \gets \text{execute}(a)$
     \State $\mathrm{Q}_{\text{new}}(s, a) \gets (1-\alpha)\,\mathrm{Q}_{\text{old}}(s,a)\;+\;\alpha\bigl(r + \gamma \max_{a'}\mathrm{Q}_{\text{old}}(s',a')\bigr)$
     \State $s \gets s'$
@@ -128,7 +128,7 @@ would allow the action to be drawn from, e.g., a continuous range of
 numbers. There are now many extensions developed based on Q-learning
 that can handle continuous state and action spaces (we'll look at one
 soon), and therefore the algorithm above is also sometimes referred to
-more  specifically as tabular Q-learning.
+more specifically as tabular Q-learning.
 
 
 In the Q-learning update rule
@@ -176,8 +176,7 @@ A typical action-selection strategy that attempts to address this *exploration v
 
 where the $\epsilon$ probability of choosing a random action helps the agent to explore and try out actions that might not seem so desirable at the moment.
 
-Q-learning has the surprising property that it is *guaranteed* to
-converge to the actual optimal $\mathrm{Q}$ function! The conditions specified in the theorem are: visit every state-action pair infinitely often, and the learning rate $\alpha$ satisfies a scheduling condition. This implies that for exploration strategy specifically, any strategy is okay as long as it tries every state-action infinitely often on an infinite run (so that it doesn't converge prematurely to a bad action choice).
+Q-learning has the surprising property that under some standard assumptions, it is *guaranteed* to converge to the actual optimal $\mathrm{Q}$ function! The conditions it needs to satisfy are: having a finite state-action space, visiting every state-action pair infinitely often, and the learning rate $\alpha$ must satisfy a scheduling condition. This implies that for exploration strategy specifically, any strategy is okay as long as it tries every state-action infinitely often on an infinite run (so that it doesn't converge prematurely to a bad action choice).
 
 Q-learning can be very inefficient. Imagine a robot that has a
 choice between moving to the left and getting a reward of 1, then
@@ -325,7 +324,7 @@ An important subtlety: the target $y$ also depends on $\theta$ (through $Q_\thet
 There are several different architectural choices for using a neural network to approximate $\mathrm{Q}$ values:
 
 - One network for each action $a$, that takes $s$ as input and produces $Q_\theta(s, a)$ as output;
-- One single network that takes $s$ as input and produces a vector $Q_\theta(s, \cdot)$, consisting of the $\mathrm{Q}$ values for each action; or
+- One single network that takes $s$ as input and produces a vector consisting of the $\mathrm{Q}$ values for each action (where the $i$th component is $Q_\theta(s,a_i)$); or
 - One single network that takes $s, a$ concatenated into a vector (if $a$ is discrete, we would probably use a one-hot encoding, unless it had some useful internal structure) and produces $Q_\theta(s, a)$ as output.
 
 :::{.column-margin}
@@ -369,7 +368,7 @@ called *fitted Q*. It uses the same Bellman-error idea as above, but cleanly sep
 
 \begin{algorithm}
 \begin{algorithmic}[1]
-  \Procedure{Fitted-Q-Learning}{$\mathcal{A}, s_0, \gamma, \alpha, \epsilon, m$}
+  \Procedure{Fitted-Q-Learning}{$\mathcal{A}, s_0, \gamma, \epsilon, m$}
     \State $s \gets s_0$ \Comment{e.g., $s_0$ can be drawn randomly from $\mathcal{S}$}
     \State $\mathcal{D} \gets \emptyset$
     \State initialize neural-network representation of $Q$
@@ -441,7 +440,7 @@ Conceptually, this is similar to having "initialized" our estimate for the trans
 
 Adding 1 and $|\mathcal{S}|$ to the numerator and denominator, respectively, is a form of smoothing called the *Laplace correction*. It ensures that we never estimate that a probability is 0, and keeps us from dividing by 0. As the amount of data we gather increases, the influence of this correction fades away.
 
-In contrast, the reward function $R(s, a)$ is a *deterministic* function, such that knowing the reward $r$ for a given $(s, a)$ is sufficient to fully determine the function at that point. Our model $\hat{R}$ can simply be a record of observed rewards, such that $\hat{R}(s, a) = r = R(s,a)$.
+Given our assumption that rewards are deterministic functions of $(s,a)$, a single observed reward is sufficient to determine $R(s,a)$. Our model $\hat{R}$ can simply be a record of observed rewards, such that $\hat{R}(s, a) = r = R(s,a)$.
 
 Given empirical models $\hat{T}$ and $\hat{R}$ for the transition and reward functions, we can now solve the MDP $(\mathcal{S}, \mathcal{A}, \hat{T}, \hat{R})$ to find an optimal policy using value iteration, or use a search algorithm to find an action to take for a particular state.
 


### PR DESCRIPTION
Replaces #55 (auto-closed by branch rename).

## Summary

Two related cleanups to the RL chapter:

### 1. Clarify the DQN / fitted-Q exposition
The "Function approximation: Deep Q learning" section and its "Fitted Q-learning" subsection were redundant and self-conflicting: the same Bellman-error idea appeared twice with no explanation of the relationship, and the fitted-Q algorithm's "re-initialize Q" line directly contradicted the surrounding catastrophic-forgetting motivation.

- Renamed parent section to **"Q-learning with function approximation"** (the prior title implied the section was about DQN specifically, which it isn't).
- Added a sentence noting that the target depends on `\theta` but is treated as a constant when computing the gradient.
- Added a **"Connection to DQN"** callout that explicitly names the third standard DQN ingredient (target network with frozen `\theta^-`), which was previously absent.
- Re-framed fitted-Q as the same Bellman-error idea with the target *explicitly* frozen as a regression label.
- Added a closing paragraph clarifying that fitted-Q and replay-buffer online Q-learning are two points on a spectrum (differing in target-refresh frequency), not rival algorithms.
- Removed the contradictory "re-initialize neural-network representation of Q" line from the fitted-Q pseudocode.
- Added `#sec-fitted_q` label.
- **Bug fix:** both pseudocode blocks declared `#| label: Q-Learning`, a collision. Renamed the second to `Fitted-Q-Learning`.
- **Bug fix:** the fitted-Q pseudocode was missing the `\begin{algorithm}...\end{algorithm}` outer wrapper that the first pseudocode block uses; added it for consistency.

### 2. Apply NOTATION.md Q-function conventions to the whole chapter
Per `NOTATION.md`:
- Line 70: all MDP functions (`\mathrm{R}`, `\mathrm{T}`, `\mathrm{V}`, `\mathrm{Q}`) use upright letters.
- Line 76: tabular Q-learning update uses `\mathrm{Q}`.
- Lines 79-81: parameterized neural-network Q-function uses italic `Q_\theta`.

The chapter previously used italic `Q`, `R`, `T` everywhere. This branch promotes:

- **Tabular Q-learning section** (lines 56-305): math-mode `Q` → `\mathrm{Q}`, `R` → `\mathrm{R}`, `T` → `\mathrm{T}`. Includes the Bellman equation, TD-Q displays, hallway example trajectory (`\mathrm{Q}^{(0)}` through `\mathrm{Q}^{(10)}`), pseudocode (`\mathrm{Q}_{\text{old}}`, `\mathrm{Q}_{\text{new}}`), and inline references in prose.
- **Function-approximation section** (lines 307-405): parametric Q references in prose, displays, and bullets promoted to `Q_\theta`. Abstract references ("the Q function we want to approximate") remain `\mathrm{Q}` to distinguish the abstract MDP object from the parameterized approximator.
- Fitted-Q pseudocode left with bare `Q` as a procedure-level variable name (algorithmic convention).

## Test plan
- [ ] Render the chapter and confirm both pseudocode blocks display with their captions/numbering
- [ ] Confirm the `Connection to DQN` callout renders correctly
- [ ] Spot-check that all displayed equations show upright `\mathrm{Q}` / `\mathrm{R}` / `\mathrm{T}` in the tabular section
- [ ] Spot-check that `Q_\theta` renders correctly in the function-approximation section
- [ ] Confirm the `#sec-fitted_q` label resolves if/when referenced
- [ ] Read over for correctness double check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/math notation and pseudocode formatting, with no runtime code or interfaces affected.
> 
> **Overview**
> Updates the RL chapter to **standardize MDP/Q-learning notation** (e.g., upright `\mathrm{Q}`, `\mathrm{R}`, `\mathrm{T}` for tabular/MDP objects and `Q_\theta` for neural approximators) and tweaks some explanatory text (e.g., bandits framing and Q-learning convergence assumptions).
> 
> Reworks the function-approximation portion by renaming it to `Q-learning with function approximation`, explicitly defining the Bellman-error loss/targets, and reframing `Fitted Q-learning` as a target-freezing variant; this also fixes the fitted-Q pseudocode (unique label, adds missing `\begin{algorithm}` wrapper, and removes the contradictory “re-initialize Q” step) and adds `#sec-fitted_q`.
> 
> Expands and clarifies the `Policy gradient` section with a more explicit objective `J(\theta)` and gradient-ascent update description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24610cc1ccbecb08756a55bb048d93565614657b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->