### PR TITLE
Fix transpose in attention scores equation

### DIFF
--- a/transformers.qmd
+++ b/transformers.qmd
@@ -80,7 +80,7 @@ $$
 The attention mechanism calculates similarity using the dot product, which efficiently measures vector similarity:
 
 $$
-a_i = \text{softmax}\left(\frac{[q_i^T k_1, q_i^T k_2, \dots, q_i^T k_n]}{\sqrt{d_k}}\right)^T \in \mathbb{R}^{1\times n}
+a_i = \text{softmax}\left(\frac{[q_i^T k_1, q_i^T k_2, \dots, q_i^T k_n]}{\sqrt{d_k}}\right) \in \mathbb{R}^{1\times n}
 $$
 
 The vector $a_i$ (softmax'd attention scores) quantifies how much attention token $q_i$ should pay to each token in the sequence, normalized so that elements sum to 1. Normalizing by $\sqrt{d_k}$ prevents large dot-product magnitudes, stabilizing training.


### PR DESCRIPTION
9.3.2: Remove outer transpose in attention scores equation

The outer transpose in the attention scores equation appears inconsistent with the stated shape $a_i \in \mathbb{R}^{1 \times n}$.

The current expression is:

$$
a_i =
\text{softmax}\left(
\frac{[q_i^T k_1, q_i^T k_2, \dots, q_i^T k_n]}
{\sqrt{d_k}}
\right)^T
\in \mathbb{R}^{1 \times n}
$$

However, the vector

$$
[q_i^T k_1, q_i^T k_2, \dots, q_i^T k_n]
$$

is treated elsewhere as a row vector of shape $1 \times n$. Applying softmax preserves that shape, so the final transpose would make it $n \times 1$, contradicting the stated shape $1 \times n$.