### PR TITLE
Unify transpose notation to \top across book

### DIFF
--- a/NOTATION.md
+++ b/NOTATION.md
@@ -13,8 +13,8 @@ Consistent notation across all course materials: notes, exams, labs, homework, a
 ### Vectors and Matrices
 - **Vectors**: bold lowercase via `\mathbf{}` -- e.g., `\mathbf{x}`
 - **Matrices**: plain uppercase -- e.g., `X, W, A`
-- **Transpose**: `X^T` or `\theta^T`
-- Column vectors by default; `\theta^T x` for dot products
+- **Transpose**: `X^\top` or `\theta^\top` (use `\top`, not `^T`, so the symbol renders upright and is visually distinct from a variable `T`)
+- Column vectors by default; `\theta^\top x` for dot products
 - Dimensions stated explicitly: `X \in \mathbb{R}^{n \times d}`, `\theta \in \mathbb{R}^d`
 
 ### Parameters and Weights
@@ -34,7 +34,7 @@ Consistent notation across all course materials: notes, exams, labs, homework, a
 - **Feature transform**: `\phi(x)` for transformed feature vector
 
 ### Neural Networks
-- Pre-activation: `Z^{(l)} = (W^{(l)})^T A^{(l-1)} + W_0^{(l)}`
+- Pre-activation: `Z^{(l)} = (W^{(l)})^\top A^{(l-1)} + W_0^{(l)}`
 - Post-activation: `A^{(l)} = f^{(l)}(Z^{(l)})`
 - Input: `A^{(0)} = x`
 - Activation functions: `f^{(l)}(\cdot)` per-layer
@@ -45,7 +45,7 @@ Consistent notation across all course materials: notes, exams, labs, homework, a
 - Gradient descent update: `\theta^{(t)} = \theta^{(t-1)} - \eta \nabla_\theta J(\theta^{(t-1)})`
 
 ### Attention Mechanism
-- Queries/keys/values: `q_i = W_q^T x_i`, `k_j = W_k^T x_j`, `v_j = W_v^T x_j`
+- Queries/keys/values: `q_i = W_q^\top x_i`, `k_j = W_k^\top x_j`, `v_j = W_v^\top x_j`
 - Attention scores: `s_{ij} = q_i \cdot k_j`
 - Softmax'd attention scores: `\alpha_{ij} = \frac{e^{s_{ij}}}{\sum_l e^{s_{il}}}` (explicit softmax formula) -- do NOT call these "attention weights"
 - Output: `z_i = \sum_j \alpha_{ij} v_j`

--- a/classification.qmd
+++ b/classification.qmd
@@ -52,13 +52,13 @@ A linear classifier in $d$ dimensions is defined by a vector of parameters $\the
 
 Given particular values for $\theta$ and $\theta_0$, the classifier is defined by 
 $$\begin{aligned}
-  h(x; \theta, \theta_0) = \text{step}(\theta^T x + \theta_0)
+  h(x; \theta, \theta_0) = \text{step}(\theta^\top x + \theta_0)
   = \begin{cases} +1 & \text{if $\theta^Tx + \theta_0 > 0$} \\ 0 &
               \text{otherwise}\end{cases} \;\;.
 \end{aligned}
 $$ 
 
-Remember that we can think of $\theta, \theta_0$ as specifying a $d$-dimensional hyperplane (compare the above with @eq-linear_reg_hypothesis). But this time, rather than being interested in that hyperplane's values at particular points $x$, we will focus on the *separator* that it induces. The separator is the set of $x$ values such that $\theta^T x + \theta_0 = 0$. This is also a hyperplane, but in $d-1$ dimensions! We can interpret $\theta$ as a vector that is perpendicular to the separator. (We will also say that $\theta$ is *normal to* the separator.) 
+Remember that we can think of $\theta, \theta_0$ as specifying a $d$-dimensional hyperplane (compare the above with @eq-linear_reg_hypothesis). But this time, rather than being interested in that hyperplane's values at particular points $x$, we will focus on the *separator* that it induces. The separator is the set of $x$ values such that $\theta^\top x + \theta_0 = 0$. This is also a hyperplane, but in $d-1$ dimensions! We can interpret $\theta$ as a vector that is perpendicular to the separator. (We will also say that $\theta$ is *normal to* the separator.) 
 
 Below is an embedded demo illustrating the separator and normal vector. Open demo in [full screen](https://shenshen.mit.edu/demos/separator.html).
 
@@ -66,7 +66,7 @@ Below is an embedded demo illustrating the separator and normal vector. Open dem
 <iframe src="https://shenshen.mit.edu/demos/separator.html" width="100%" height="600px" frameborder="2"></iframe>
 :::
 
-For example, in two dimensions ($d=2$) the separator has dimension 1, which means it is a line, and the two components of $\theta = [\theta_1, \theta_2]^T$ give the orientation of the separator, as illustrated in the following example.
+For example, in two dimensions ($d=2$) the separator has dimension 1, which means it is a line, and the two components of $\theta = [\theta_1, \theta_2]^\top$ give the orientation of the separator, as illustrated in the following example.
 
 ### Linear classifiers: examples
 
@@ -106,7 +106,7 @@ The diagram below shows the $\theta$ vector (in green) and the separator it defi
 \end{tikzpicture}
 :::
 
-What is $\theta_0$? We can solve for it by plugging a point on the line into the equation for the line. It is often convenient to choose a point on one of the axes, e.g., in this case, $x=[0, 1]^T$, for which $\theta^T \left[ \begin{array}{c} 0 \\ 1 \end{array} \right] + \theta_0 = 0$, giving $\theta_0 = 1$.
+What is $\theta_0$? We can solve for it by plugging a point on the line into the equation for the line. It is often convenient to choose a point on one of the axes, e.g., in this case, $x=[0, 1]^\top$, for which $\theta^\top \left[ \begin{array}{c} 0 \\ 1 \end{array} \right] + \theta_0 = 0$, giving $\theta_0 = 1$.
 :::
 
 In this example, the separator divides $\mathbb{R}^d$, the space our $x^{(i)}$ points live in, into two half-spaces. The one that is on the same side as the normal vector is the *positive* half-space, and we classify all points in that space as positive. The half-space on the other side is *negative* and all points in it are classified as negative.
@@ -178,7 +178,7 @@ For these reasons, if we are considering a hypothesis $\theta,\theta_0$ that mak
 
 The hypotheses in a linear logistic classifier (LLC) are parameterized by a $d$-dimensional vector $\theta$ and a scalar $\theta_0$, just as is the case for linear classifiers. However, instead of making predictions in $\{+1, 0\}$, LLC hypotheses generate real-valued outputs in the interval $(0, 1)$. An LLC has the form 
 $$
-h(x; \theta, \theta_0) = \sigma(\theta^T x + \theta_0)\;\;.
+h(x; \theta, \theta_0) = \sigma(\theta^\top x + \theta_0)\;\;.
 $$ 
 This looks familiar! What's new?
 
@@ -234,7 +234,7 @@ What does an LLC look like? Let's consider the simple case where $d = 1$, so our
         height=0.3\textwidth,
         xmin=-4, xmax=4,
         ymin=-0.25, ymax=1.25,
-        xlabel={$x$}, ylabel={$\sigma(\theta^T x + \theta_0)$},
+        xlabel={$x$}, ylabel={$\sigma(\theta^\top x + \theta_0)$},
       ]
       \addplot [domain=-4:4, samples=100, ultra thick, red] {1/(1+exp(-(10*x + 1)))};
       \addplot [domain=-4:4, samples=100, ultra thick, blue] {1/(1+exp(-(-2*x
@@ -255,7 +255,7 @@ Which plot is which?  What governs the steepness of the curve?  What governs the
 But wait! Remember that the definition of a classifier is that it's a mapping from 
 $\mathbb{R}^d  \rightarrow \{+1, 0\}$ or to some other discrete set. So, then, it seems like an LLC is actually not a classifier!
 
-Given an LLC, with an output value in $(0, 1)$, what should we do if we are forced to make a prediction in $\{+1, 0\}$? A default answer is to predict $+1$ if $\sigma(\theta^T x + \theta_0) > 0.5$ and $0$ otherwise. The value $0.5$ is sometimes called a *prediction threshold*.
+Given an LLC, with an output value in $(0, 1)$, what should we do if we are forced to make a prediction in $\{+1, 0\}$? A default answer is to predict $+1$ if $\sigma(\theta^\top x + \theta_0) > 0.5$ and $0$ otherwise. The value $0.5$ is sometimes called a *prediction threshold*.
 
 In fact, for different problem settings, we might prefer to pick a different prediction threshold. The field of *decision theory* considers how to make this choice. For example, if the consequences of predicting $+1$ when the answer should be $0$ are much worse than the consequences of predicting $0$ when the answer should be $+1$, then we might set the prediction threshold to be greater than $0.5$.
 
@@ -270,7 +270,7 @@ When $d = 2$, then our inputs $x$ lie in a two-dimensional space with axes $x_1$
 
 :::{.study-question-callout}
 Convince yourself that the set of points for which
-  $\sigma(\theta^T x + \theta_0) = 0.5$, that is, the ``boundary''
+  $\sigma(\theta^\top x + \theta_0) = 0.5$, that is, the ``boundary''
   between positive and negative predictions with prediction threshold
   $0.5$, is a line in $(x_1, x_2)$ space. What particular line is it
   for the case in the figure above?
@@ -347,7 +347,7 @@ The choice of log base doesn't make any real difference here. When we ask you fo
 $$
 J_\text{lr}(\theta, \theta_0; {\cal D}) =
   \left(\frac{1}{n} \sum_{i=1}^n
-  \mathcal{L}_\text{nll}(\sigma(\theta^T x^{(i)} + \theta_0), y^{(i)})\right) +
+  \mathcal{L}_\text{nll}(\sigma(\theta^\top x^{(i)} + \theta_0), y^{(i)})\right) +
   \lambda \left\lVert\theta\right\rVert^2\;\;.
 $${#eq-lr_with_reg}
 
@@ -414,8 +414,8 @@ What is the shape of $\nabla_\theta \|\theta\|^2$?
 :::
 
 ::: {.study-question-callout}
-Compute $\nabla_\theta \mathcal{L}_\text{nll}\bigl(\sigma(\theta^T x + \theta_0), y\bigr)$ by finding the vector of partial derivatives 
-$\left(\frac{\partial \mathcal{L}_\text{nll}\bigl(\sigma(\theta^T x + \theta_0), y\bigr)}{\partial \theta_1}, \ldots, \frac{\partial \mathcal{L}_\text{nll}\bigl(\sigma(\theta^T x + \theta_0), y\bigr)}{\partial \theta_d}\right)$.
+Compute $\nabla_\theta \mathcal{L}_\text{nll}\bigl(\sigma(\theta^\top x + \theta_0), y\bigr)$ by finding the vector of partial derivatives 
+$\left(\frac{\partial \mathcal{L}_\text{nll}\bigl(\sigma(\theta^\top x + \theta_0), y\bigr)}{\partial \theta_1}, \ldots, \frac{\partial \mathcal{L}_\text{nll}\bigl(\sigma(\theta^\top x + \theta_0), y\bigr)}{\partial \theta_d}\right)$.
 :::
 
 ::: {.study-question-callout}
@@ -466,7 +466,7 @@ We will use the following facts to demonstrate that the NLL loss function for li
 
 -   a convex function of an affine function is a convex function.
 
-Let $z=\theta^T x + \theta_0$; $z$ is an affine function of $\theta$ and $\theta_0$. It therefore suffices to show that the functions $f_1(z) \coloneqq -\log \sigma(z)$ and $f_2 (z) \coloneqq -\log (1 - \sigma(z))$ are convex with respect to $z$.
+Let $z=\theta^\top x + \theta_0$; $z$ is an affine function of $\theta$ and $\theta_0$. It therefore suffices to show that the functions $f_1(z) \coloneqq -\log \sigma(z)$ and $f_2 (z) \coloneqq -\log (1 - \sigma(z))$ are convex with respect to $z$.
 
 First, we can see that since, 
 $$
@@ -500,16 +500,16 @@ So far, we have focused on the *binary* classification case, with only two possi
 
 -   Directly train a multi-class classifier using a hypothesis class that is a generalization of logistic regression, using a *one-hot* output encoding and NLL loss.
 
-The method based on NLL is in wider use, especially in the context of neural networks, and is explored here. In the following, we will assume that we have a data set ${\cal D}$ in which the inputs $x^{(i)} \in R^d$ but the outputs $y^{(i)}$ are drawn from a set of $K$ classes $\{c_1, \ldots, c_K\}$. Next, we extend the idea of NLL directly to multi-class classification with $K$ classes, where the training label is represented with what is called a *one-hot* vector $y=\begin{bmatrix} y_1, \ldots, y_K \end{bmatrix}^T$, where $y_k=1$ if the example is of class $k$ and $y_k = 0$ otherwise. Now, we have a problem of mapping an input $x^{(i)}$ that is in $\mathbb{R}^d$ into a $K$-dimensional output. Furthermore, we would like this output to be interpretable as a discrete probability distribution over the possible classes, which means the elements of the output vector have to be *non-negative* (greater than or equal to 0) and sum to 1.
+The method based on NLL is in wider use, especially in the context of neural networks, and is explored here. In the following, we will assume that we have a data set ${\cal D}$ in which the inputs $x^{(i)} \in R^d$ but the outputs $y^{(i)}$ are drawn from a set of $K$ classes $\{c_1, \ldots, c_K\}$. Next, we extend the idea of NLL directly to multi-class classification with $K$ classes, where the training label is represented with what is called a *one-hot* vector $y=\begin{bmatrix} y_1, \ldots, y_K \end{bmatrix}^\top$, where $y_k=1$ if the example is of class $k$ and $y_k = 0$ otherwise. Now, we have a problem of mapping an input $x^{(i)}$ that is in $\mathbb{R}^d$ into a $K$-dimensional output. Furthermore, we would like this output to be interpretable as a discrete probability distribution over the possible classes, which means the elements of the output vector have to be *non-negative* (greater than or equal to 0) and sum to 1.
 
 We will do this in two steps. First, we will map our input $x^{(i)}$ into a vector value $z^{(i)} \in \mathbb{R}^K$ by letting $\theta$ be a whole $d \times K$ *matrix* of parameters, and $\theta_0$ be a $K \times 1$ vector, so that 
 
 $$
-z = \theta^T x + \theta_0\;\;.
+z = \theta^\top x + \theta_0\;\;.
 $$ 
 
 :::{.column-margin}
-Let's check dimensions!  $\theta^T$ is $K \times d$ and $x$ is
+Let's check dimensions!  $\theta^\top$ is $K \times d$ and $x$ is
     $d \times 1$, and $\theta_0$ is $K \times 1$, so $z$ is $K \times
       1$ and we're good!
 :::
@@ -529,7 +529,7 @@ which can be interpreted as a probability distribution over $K$ items. To make t
 Convince yourself that the vector of $g$ values will be non-negative and sum to 1.
 :::
 
-Putting these steps together, our hypotheses will be $$h(x; \theta, \theta_0) = \operatorname{softmax}(\theta^T x + \theta_0)\;\;.$$
+Putting these steps together, our hypotheses will be $$h(x; \theta, \theta_0) = \operatorname{softmax}(\theta^\top x + \theta_0)\;\;.$$
 
 Now, we retain the goal of maximizing the probability that our hypothesis assigns to the correct output $y_k$ for each input $x$. We can write this probability, letting $g$ stand for our "guess", $h(x)$, for a single example $(x, y)$ as $\prod_{k = 1}^K g_k^{y_k}$.
 

--- a/classification.qmd
+++ b/classification.qmd
@@ -53,7 +53,7 @@ A linear classifier in $d$ dimensions is defined by a vector of parameters $\the
 Given particular values for $\theta$ and $\theta_0$, the classifier is defined by 
 $$\begin{aligned}
   h(x; \theta, \theta_0) = \text{step}(\theta^\top x + \theta_0)
-  = \begin{cases} +1 & \text{if $\theta^Tx + \theta_0 > 0$} \\ 0 &
+  = \begin{cases} +1 & \text{if $\theta^\top x + \theta_0 > 0$} \\ 0 &
               \text{otherwise}\end{cases} \;\;.
 \end{aligned}
 $$ 

--- a/convolutional_neural_networks.qmd
+++ b/convolutional_neural_networks.qmd
@@ -474,7 +474,7 @@ For simplicity assume $k$ is odd, let the input image $X = A^0$, and assume we a
   Z_i^1                        & = {W^1}^TA^0_{[i-\lfloor k/2 \rfloor
   : i + \lfloor k/2 \rfloor]}                                         \\
   A^1                          & = ReLU(Z^1)                          \\
-  A^2                          & = Z^2 = {W^2}^T A^1                  \\
+  A^2                          & = Z^2 = {W^2}^\top A^1                  \\
   \mathcal{L}_{square}(A^2, y) & = (A^2-y)^2
 \end{aligned}$$
 

--- a/convolutional_neural_networks.qmd
+++ b/convolutional_neural_networks.qmd
@@ -471,7 +471,7 @@ Let's work through a *very* simple example of how back-propagation can work on a
 
 
 For simplicity assume $k$ is odd, let the input image $X = A^0$, and assume we are using squared loss. Then we can describe the forward pass as follows: $$\begin{aligned}
-  Z_i^1                        & = {W^1}^TA^0_{[i-\lfloor k/2 \rfloor
+  Z_i^1                        & = {W^1}^\top A^0_{[i-\lfloor k/2 \rfloor
   : i + \lfloor k/2 \rfloor]}                                         \\
   A^1                          & = ReLU(Z^1)                          \\
   A^2                          & = Z^2 = {W^2}^\top A^1                  \\

--- a/feature_representation.qmd
+++ b/feature_representation.qmd
@@ -6,7 +6,7 @@ Linear regression and classification are powerful tools, but in the real world, 
 
 Such behavior is actually ubiquitous in physical systems, e.g., in the vibrations of the surface of a drum, or scattering of light through an aperture. However, no single hyperplane would be a very good fit to such peaked responses!
 
-A richer class of hypotheses can be obtained by performing a non-linear feature transformation $\phi(x)$ before doing the regression. That is, $\theta^Tx + \theta_0$ is a linear function of $x$, but $\theta^T\phi(x) + \theta_0$ is a non-linear function of $x,$ if $\phi$ is a non-linear function of $x$.
+A richer class of hypotheses can be obtained by performing a non-linear feature transformation $\phi(x)$ before doing the regression. That is, $\theta^Tx + \theta_0$ is a linear function of $x$, but $\theta^\top\phi(x) + \theta_0$ is a non-linear function of $x,$ if $\phi$ is a non-linear function of $x$.
 
 There are many different ways to construct $\phi$. Some are relatively systematic and domain independent. Others are directly related to the semantics (meaning) of the original features, and we construct them deliberately with our application (goal) in mind.
 
@@ -43,7 +43,7 @@ Let's look at an example data set that starts in 1-D:
 :::
 :::
 
-These points are not linearly separable, but consider the transformation $\phi(x) = [x,x^2]^T$. Plotting this transformed data (in two-dimensional space, since there are now two features), we see that it is now separable. There are lots of possible separators; we have just shown one of them here.
+These points are not linearly separable, but consider the transformation $\phi(x) = [x,x^2]^\top$. Plotting this transformed data (in two-dimensional space, since there are now two features), we see that it is now separable. There are lots of possible separators; we have just shown one of them here.
 
 :::{.callout-note}
 ## Example
@@ -77,7 +77,7 @@ These points are not linearly separable, but consider the transformation $\phi(x
 :::
 :::
 
-A linear separator in $\phi$ space is a non-linear separator in the original space! Let's see how this plays out in our simple example. Consider the separator $x^2  - 1 = 0$ (which corresponds to $\theta = [0,1]^T$ and $\theta_0 = -1$ in our transformed space), which labels the half-plane $x^2 -1 > 0$ as positive. What separator does it correspond to in the original 1-D space? We have to ask the question: which $x$ values have the property that $x^2 - 1 = 0$. The answer is $+1$ and $-1$, so those two points constitute our separator, back in the original space. Similarly, by evaluating where $x^2 - 1 > 0$ and where $x^2 - 1 < 0$, we can find the regions of 1D space that are labeled positive and negative (respectively) by this separator.
+A linear separator in $\phi$ space is a non-linear separator in the original space! Let's see how this plays out in our simple example. Consider the separator $x^2  - 1 = 0$ (which corresponds to $\theta = [0,1]^\top$ and $\theta_0 = -1$ in our transformed space), which labels the half-plane $x^2 -1 > 0$ as positive. What separator does it correspond to in the original 1-D space? We have to ask the question: which $x$ values have the property that $x^2 - 1 = 0$. The answer is $+1$ and $-1$, so those two points constitute our separator, back in the original space. Similarly, by evaluating where $x^2 - 1 > 0$ and where $x^2 - 1 < 0$, we can find the regions of 1D space that are labeled positive and negative (respectively) by this separator.
 
 :::{.callout-note}
 ## Example
@@ -135,12 +135,12 @@ Here is a table illustrating the $k$th order polynomial basis for different valu
 | Order |       $d=1$       |        in general ($d>1$)        |
 |:-----:|:-----------------:|:--------------------------------:|
 |   0   |       $[1]$       |              $[1]$               |
-|   1   |     $[1,x]^T$     |     $[1,x_1, \ldots, x_d]^T$     |
-|   2   |   $[1,x,x^2]^T$   |       $[1,x_1, \ldots, x_d,      
-                                   x_1^2, x_1x_2, \ldots]^T$   |
-|   3   | $[1,x,x^2,x^3]^T$ |         $[1,x_1, \ldots, x_d,        
+|   1   |     $[1,x]^\top$     |     $[1,x_1, \ldots, x_d]^\top$     |
+|   2   |   $[1,x,x^2]^\top$   |       $[1,x_1, \ldots, x_d,      
+                                   x_1^2, x_1x_2, \ldots]^\top$   |
+|   3   | $[1,x,x^2,x^3]^\top$ |         $[1,x_1, \ldots, x_d,        
                                         x_1^2, x_1x_2, \ldots, 
-                                     x_1^3, x_1x_2^2, x_1x_2x_3, \ldots]^T$     |
+                                     x_1^3, x_1x_2^2, x_1x_2x_3, \ldots]^\top$     |
 |   ⋮   |         ⋮         |                ⋮                 |
 :::
 
@@ -188,7 +188,7 @@ Clearly, this data set is not linearly separable. So, what if we try to solve th
 
 Let's try it for $k = 2$ on our xor problem. The feature transformation is 
 $$
-\phi([x_1, x_2]^T) = [1, x_1, x_2, x_1^2, x_1 x_2, x_2^2]^T\;\;.
+\phi([x_1, x_2]^\top) = [1, x_1, x_2, x_1^2, x_1 x_2, x_2^2]^\top\;\;.
 $$ 
 
 :::{.study-question-callout}
@@ -199,7 +199,7 @@ If we train a classifier after performing this feature
 :::
 
 
-We might run a classification learning algorithm and find a separator with coefficients $\theta = [0, 0, 0, 0, 4, 0]^T$ and $\theta_0 = 0$. This corresponds to $$0 + 0 x_1 + 0 x_2 + 0 x_1^2 + 4 x_1 x_2 + 0 x_2^2 + 0 = 0$$ and is plotted below, with the gray shaded region classified as negative and the white region classified as positive:
+We might run a classification learning algorithm and find a separator with coefficients $\theta = [0, 0, 0, 0, 4, 0]^\top$ and $\theta_0 = 0$. This corresponds to $$0 + 0 x_1 + 0 x_2 + 0 x_1^2 + 4 x_1 x_2 + 0 x_2^2 + 0 = 0$$ and is plotted below, with the gray shaded region classified as negative and the white region classified as positive:
 
 :::{.callout-note}
 ## Example
@@ -254,7 +254,7 @@ Let's start with the basic case, in which $\mathcal{X} = \mathbb{R}^d$. Then we 
 The parameter $\beta$ governs how quickly the feature value decays as we move away from the center point $p$. For large values of $\beta$, the $f_p$ values are nearly 0 almost everywhere except right near $p$; for small values of $\beta$, the features have a high value over a larger part of the space.
 
 Now, given a dataset ${\cal D}$ containing $n$ points, we can make a feature transformation $\phi$ that maps points in our original space, $\mathbb{R}^d$, into points in a new space, $\mathbb{R}^n$. It is defined as follows: $$\phi(x) = [f_{x^{(1)}}(x), f_{x^{(2)}}(x), \ldots,
-  f_{x^{(n)}}(x)]^T\;\;.$$ So, we represent a new datapoint $x$ in terms of how far it is from each of the datapoints in our training set.
+  f_{x^{(n)}}(x)]^\top\;\;.$$ So, we represent a new datapoint $x$ in terms of how far it is from each of the datapoints in our training set.
 
 This idea can be generalized in several ways and is the fundamental concept underlying *kernel methods*, that are not directly covered in this class but we recommend you read about sometime. This idea of describing objects in terms of their similarity to a set of reference objects is very powerful and can be applied to cases where $\mathcal{X}$ is not a simple vector space, but where the inputs are graphs or strings or other types of objects, as long as there is a distance metric defined on the input space.
 
@@ -284,7 +284,7 @@ As an example, imagine that we want to encode blood types, that are drawn from t
 
 -   Use a 6-D vector, with two components of the vector each encoding the corresponding factor using a one-hot encoding.
 
--   Use a 3-D vector, with one dimension for each factor, encoding its presence as $1.0$ and absence as $-1.0$ (this is sometimes better than $0.0$). In this case, $AB+$ would be $[1.0, 1.0, 1.0]^T$ and $O-$ would be $[-1.0, -1.0, -1.0]^T$.
+-   Use a 3-D vector, with one dimension for each factor, encoding its presence as $1.0$ and absence as $-1.0$ (this is sometimes better than $0.0$). In this case, $AB+$ would be $[1.0, 1.0, 1.0]^\top$ and $O-$ would be $[-1.0, -1.0, -1.0]^\top$.
 
 :::{.study-question-callout}
 How would you encode $A+$ in both of these approaches?

--- a/feature_representation.qmd
+++ b/feature_representation.qmd
@@ -6,7 +6,7 @@ Linear regression and classification are powerful tools, but in the real world, 
 
 Such behavior is actually ubiquitous in physical systems, e.g., in the vibrations of the surface of a drum, or scattering of light through an aperture. However, no single hyperplane would be a very good fit to such peaked responses!
 
-A richer class of hypotheses can be obtained by performing a non-linear feature transformation $\phi(x)$ before doing the regression. That is, $\theta^Tx + \theta_0$ is a linear function of $x$, but $\theta^\top\phi(x) + \theta_0$ is a non-linear function of $x,$ if $\phi$ is a non-linear function of $x$.
+A richer class of hypotheses can be obtained by performing a non-linear feature transformation $\phi(x)$ before doing the regression. That is, $\theta^\top x + \theta_0$ is a linear function of $x$, but $\theta^\top\phi(x) + \theta_0$ is a non-linear function of $x,$ if $\phi$ is a non-linear function of $x$.
 
 There are many different ways to construct $\phi$. Some are relatively systematic and domain independent. Others are directly related to the semantics (meaning) of the original features, and we construct them deliberately with our application (goal) in mind.
 

--- a/gradient_descent.qmd
+++ b/gradient_descent.qmd
@@ -167,11 +167,11 @@ $$
 
 We use the gradient of the objective with respect to the parameters: 
 
-$$\nabla_{\theta}J = \frac{2}{n}\underbrace{{X}^T}_{d \times
+$$\nabla_{\theta}J = \frac{2}{n}\underbrace{{X}^\top}_{d \times
     n}\underbrace{({X}\theta - {Y})}_{n \times 1}\;\;,
 $${#eq-reg_gd_deriv} to obtain an analytical solution to the linear regression problem. Gradient descent could also be applied to numerically compute a solution, using the update rule 
 $$
-\theta^{(t)} = \theta^{(t-1)} - \eta \frac{2}{n} \sum_{i=1}^{n} \left( \left[ \theta^{(t-1)}\right]^T x^{(i)} - y^{(i)} \right) x^{(i)}
+\theta^{(t)} = \theta^{(t-1)} - \eta \frac{2}{n} \sum_{i=1}^{n} \left( \left[ \theta^{(t-1)}\right]^\top x^{(i)} - y^{(i)} \right) x^{(i)}
   \,.
 $$
 
@@ -217,11 +217,11 @@ Compute $\nabla_\theta ||\theta||^2$ by finding the
 
 ::: {.study-question-callout}
 Compute $\nabla_\theta J_\text{ridge}(
-    \theta^T x + \theta_0, y)$ by finding the
+    \theta^\top x + \theta_0, y)$ by finding the
   vector of partial derivatives $(\partial J_\text{ridge}(
-    \theta^T x + \theta_0, y)/ \partial \theta_1, \ldots,
+    \theta^\top x + \theta_0, y)/ \partial \theta_1, \ldots,
     \partial J_\text{ridge}(
-    \theta^T x + \theta_0, y) / \partial
+    \theta^\top x + \theta_0, y) / \partial
     \theta_d)$.
 :::
 
@@ -249,12 +249,12 @@ Putting everything together, our gradient descent algorithm for ridge regression
   \Repeat
     \State   $t \gets t+1$
     \State   $\theta^{(t)} = \theta^{(t-1)} - \eta\left(\frac{1}{n}\sum_{i=1}^n
-    \left({{\theta}^{(t-1)}}^T {x}^{(i)} + {\theta_0}^{(t-1)} -
+    \left({{\theta}^{(t-1)}}^\top {x}^{(i)} + {\theta_0}^{(t-1)} -
       {y}^{(i)}\right) {x}^{(i)}
     + \lambda{\theta}^{(t-1)}
     \right)$
   \State $\theta_0^{(t)} = \theta_0^{(t-1)} - \eta\left(\frac{1}{n}\sum_{i=1}^n
-    \left({{\theta}^{(t-1)}}^T {x}^{(i)} + {\theta_0}^{(t-1)} -
+    \left({{\theta}^{(t-1)}}^\top {x}^{(i)} + {\theta_0}^{(t-1)} -
       {y}^{(i)} \right)
     \right)$
   \Until{$\left| J_{\text{ridge}}(\theta^{(t)},\theta_0^{(t)}) - J_{\text{ridge}}(\theta^{(t-1)},\theta_0^{(t-1)}) \right| <\epsilon$}
@@ -264,7 +264,7 @@ Putting everything together, our gradient descent algorithm for ridge regression
 \end{algorithm}
 ```
 :::{.column-margin}
-Beware double superscripts!  $\left[ \theta \right]^T$ is the transpose of the vector $\theta$.
+Beware double superscripts!  $\left[ \theta \right]^\top$ is the transpose of the vector $\theta$.
 :::
 
 :::{.study-question-callout}

--- a/gradient_descent.qmd
+++ b/gradient_descent.qmd
@@ -162,7 +162,7 @@ Which termination criteria from the 1D case were defined in a way that assumes $
 Recall from the previous chapter that choosing a loss function is the first step in formulating a machine-learning problem as an optimization problem, and for regression we studied the mean-squared loss, which captures loss as $({\rm guess} - {\rm actual})^2$. This leads to the *ordinary least squares* objective 
 
 $$J(\theta) = \frac{1}{n}\sum_{i =
-    1}^n\left(\theta^Tx^{(i)} - y^{(i)}\right)^2 \;\;.   
+    1}^n\left(\theta^\top x^{(i)} - y^{(i)}\right)^2 \;\;.   
 $$ 
 
 We use the gradient of the objective with respect to the parameters: 

--- a/index.qmd
+++ b/index.qmd
@@ -236,7 +236,7 @@ We will find that minimizing training error alone is often not a good choice: it
 
 ## Model class and parameter fitting {#modelClass}
 
-A model *class* ${\cal M}$ is a set of possible models, typically parameterized by a vector of parameters $\Theta$. What assumptions will we make about the form of the model? When solving a regression problem using a prediction-rule approach, we might try to find a linear function $h(x ; \theta, \theta_0) = \theta^T x + \theta_0$ that fits our data well. In this example, the parameter vector $\Theta = (\theta, \theta_0)$.
+A model *class* ${\cal M}$ is a set of possible models, typically parameterized by a vector of parameters $\Theta$. What assumptions will we make about the form of the model? When solving a regression problem using a prediction-rule approach, we might try to find a linear function $h(x ; \theta, \theta_0) = \theta^\top x + \theta_0$ that fits our data well. In this example, the parameter vector $\Theta = (\theta, \theta_0)$.
 
 For problem types such as classification, there are huge numbers of model classes that have been considered\...we'll spend much of this course exploring these model classes, especially neural networks models. We will almost completely restrict our attention to model classes with a fixed, finite number of parameters. Models that relax this assumption are called "non-parametric" models.
 

--- a/matrix_calculus.qmd
+++ b/matrix_calculus.qmd
@@ -21,7 +21,7 @@ We can even, in a very hand-waving way, think of the $dx$'s canceling out nicely
 In multi-variable calculus, we have $x \in \mathbb{R}^n$ and $f(x): \mathbb{R}^n \rightarrow \mathbb{R}^m$. We will use the following notation, which may seem a bit counter-intuitive at first:
 
 $$
-df = \frac{df}{dx}^T dx
+df = \frac{df}{dx}^\top dx
 $$
 
 We are **intentionally** adding a transpose to the $\frac{df}{dx}$ term. This means that $\frac{df}{dx}$ will be of size $(n \times m)$. The input ($x$) determines the rows in the derivative, and the output ($f$) determines the columns in the derivative. In other words:
@@ -122,13 +122,13 @@ $$
 This exactly matches our standard denominator layout form:
 
 $$
-df = \frac{df}{d\theta}^T d\theta
+df = \frac{df}{d\theta}^\top d\theta
 $$
 
 where:
 
 $$
-\frac{df}{d\theta} = X^T
+\frac{df}{d\theta} = X^\top
 $$
 
 Done!
@@ -165,9 +165,9 @@ $$
 \begin{align*}
 df &= f(v + dv) - f(v) \\
    &= ||(v + dv)||^2 - ||v||^2 \\
-   &= (v + dv)^T(v + dv) - ||v||^2 \\
-   &= ||v||^2 + v^T dv + (dv)^T v + ||dv||^2 - ||v||^2 \\
-   &= (2v)^T dv + ||dv||^2
+   &= (v + dv)^\top(v + dv) - ||v||^2 \\
+   &= ||v||^2 + v^\top dv + (dv)^\top v + ||dv||^2 - ||v||^2 \\
+   &= (2v)^\top dv + ||dv||^2
 \end{align*}
 $$
 
@@ -176,13 +176,13 @@ Just like in single-variable calculus, we can drop the squared $dv$ term since i
 Thus we are left with
 
 $$
-df = (2v)^T dv
+df = (2v)^\top dv
 $$
 
 Comparing this to our standard form:
 
 $$
-df = \frac{df}{dv}^T dv
+df = \frac{df}{dv}^\top dv
 $$
 
 we see clearly that
@@ -198,22 +198,22 @@ This is where the advantage of matrix calculus—and more specifically the denom
 Let us assume we have a composition of functions $f(g(x))$. We want to calculate the derivative of $f$ with respect to $x$. As a first step, let's just look at how $f$ changes with respect to $g$:
 
 $$
-df = \frac{df}{dg}^T \cdot dg
+df = \frac{df}{dg}^\top \cdot dg
 $$
 
 Now we also know how $dg$ changes with respect to $dx$, so we can substitute that in:
 
 $$
-df = \frac{df}{dg}^T \cdot \left(\frac{dg}{dx}^T \cdot dx\right)
+df = \frac{df}{dg}^\top \cdot \left(\frac{dg}{dx}^\top \cdot dx\right)
 $$
 
 Simplifying gives:
 
 $$
 \begin{align*}
-df &= \frac{df}{dg}^T \cdot \left(\frac{dg}{dx}^T \cdot dx\right) \\
-   &= \left(\frac{df}{dg}^T \cdot \frac{dg}{dx}^T\right) \cdot dx \\
-   &= \left(\frac{dg}{dx} \cdot \frac{df}{dg}\right)^T \cdot dx
+df &= \frac{df}{dg}^\top \cdot \left(\frac{dg}{dx}^\top \cdot dx\right) \\
+   &= \left(\frac{df}{dg}^\top \cdot \frac{dg}{dx}^\top\right) \cdot dx \\
+   &= \left(\frac{dg}{dx} \cdot \frac{df}{dg}\right)^\top \cdot dx
 \end{align*}
 $$
 
@@ -276,11 +276,11 @@ $$\begin{aligned}
 
 Therefore, the $(i,j)$ entry of $\frac{\partial {\bf A}{\bf x}}{\partial {\bf x}}$ is the $(j,i)$ entry of ${\bf A}$:
 
-$$\frac{\partial {\bf A}{\bf x}}{\partial {\bf x}} = {\bf A}^T$${#eq-Ax}
+$$\frac{\partial {\bf A}{\bf x}}{\partial {\bf x}} = {\bf A}^\top$${#eq-Ax}
 
 Similarly, for objects ${\bf x}, {\bf A}$ of the same shape, one can obtain,
 
-$$\frac{\partial {\bf x}^T {\bf A}}{\partial {\bf x}} = {\bf A}
+$$\frac{\partial {\bf x}^\top {\bf A}}{\partial {\bf x}} = {\bf A}
 $${#eq-xTA}
 
 ### Linearity of Derivatives
@@ -300,16 +300,16 @@ $$
 One can extend the previous identity to vector- and matrix-valued constants. Suppose that ${\bf a}$ is a vector with shape $m \times 1$ and $v$ is a scalar which depends on ${\bf x}$. Then,
 
 $$\frac{\partial v {\bf a}}{\partial {\bf x}} = \frac{\partial
-    v}{\partial {\bf x}}{\bf a}^T
+    v}{\partial {\bf x}}{\bf a}^\top
 $$
 
-First, checking dimensions, $\partial v/\partial {\bf x}$ is $n \times 1$ and ${\bf a}$ is $m \times 1$ so ${\bf a}^T$ is $1 \times m$ and our answer is $n \times m$ as it should be. Now, checking a value, element $(i,j)$ of the answer is $\partial v {\bf a}_j / \partial x_i$ = $(\partial v / \partial x_i) {\bf a}_j$ which corresponds to element $(i,j)$ of $(\partial v / \partial {\bf x}){\bf a}^T$.
+First, checking dimensions, $\partial v/\partial {\bf x}$ is $n \times 1$ and ${\bf a}$ is $m \times 1$ so ${\bf a}^\top$ is $1 \times m$ and our answer is $n \times m$ as it should be. Now, checking a value, element $(i,j)$ of the answer is $\partial v {\bf a}_j / \partial x_i$ = $(\partial v / \partial x_i) {\bf a}_j$ which corresponds to element $(i,j)$ of $(\partial v / \partial {\bf x}){\bf a}^\top$.
 
 Similarly, suppose that ${\bf A}$ is a matrix which does not depend on ${\bf x}$ and ${\bf u}$ is a column vector which does depend on ${\bf x}$. Then,
 
 $$
 \frac{\partial {\bf A}{\bf u}}{\partial {\bf x}} = \frac{\partial
-    {\bf u}}{\partial {\bf x}}{\bf A}^T
+    {\bf u}}{\partial {\bf x}}{\bf A}^\top
 $$
 
 ### Product Rule (Vector-valued Numerator)
@@ -318,7 +318,7 @@ Suppose that $v$ is a scalar which depends on ${\bf x}$, while ${\bf u}$ is a co
 
 $$
 \frac{\partial v {\bf u}}{\partial {\bf x}} = v\frac{\partial
-    {\bf u}}{\partial {\bf x}} + \frac{\partial v}{\partial {\bf x}} {\bf u}^T
+    {\bf u}}{\partial {\bf x}} + \frac{\partial v}{\partial {\bf x}} {\bf u}^\top
 $$
 
 One can see this relationship by expanding the derivative as follows:
@@ -363,12 +363,12 @@ $$
 You can get many scalar-by-vector and vector-by-scalar cases as special cases of the rules above, making one of the relevant vectors just be 1 x 1. Here are some other ones that are handy. For more, see the Wikipedia article on Matrix derivatives (for consistency, only use the ones in *denominator layout*).
 
 $$
-\frac{\partial {\bf u}^T {\bf v}}{\partial {\bf x}} = \frac{\partial
+\frac{\partial {\bf u}^\top {\bf v}}{\partial {\bf x}} = \frac{\partial
     {\bf u}}{\partial {\bf x}} {\bf v}+ \frac{\partial {\bf v}}{\partial {\bf x}} {\bf u}
 $${#eq-uTv}
 
-$$\frac{\partial {\bf u}^T}{\partial x} = \big(\frac{\partial
-    {\bf u}}{\partial x}\big)^T
+$$\frac{\partial {\bf u}^\top}{\partial x} = \big(\frac{\partial
+    {\bf u}}{\partial x}\big)^\top
 $${#eq-uT}
 
 ## MSE for Linear Regression
@@ -379,16 +379,16 @@ $$
 J(\theta) = \frac{1}{n} ||X\theta - Y||^2
 $$
 
-where $X$ and $\theta$ are the augmented forms to allow for an intercept. Let us show how to optimize this function by setting its gradient equal to 0. We combine all of the facts that we learned. We know that the derivative of $||v||^2$ with respect to $v$ is $2v$, the derivative of $X\theta$ with respect to $\theta$ is $X^T$, and we know the chain rule. Combining all of that gives:
+where $X$ and $\theta$ are the augmented forms to allow for an intercept. Let us show how to optimize this function by setting its gradient equal to 0. We combine all of the facts that we learned. We know that the derivative of $||v||^2$ with respect to $v$ is $2v$, the derivative of $X\theta$ with respect to $\theta$ is $X^\top$, and we know the chain rule. Combining all of that gives:
 
 $$
-\frac{dJ}{d\theta} = \frac{2}{n} X^T \cdot (X\theta - Y)
+\frac{dJ}{d\theta} = \frac{2}{n} X^\top \cdot (X\theta - Y)
 $$
 
 Now, to optimize, we set the derivative equal to 0:
 
 $$
-\frac{dJ}{d\theta} = \frac{2}{n} X^T \cdot (X\theta - Y) = 0 \implies \theta^* = (X^TX)^{-1}X^TY
+\frac{dJ}{d\theta} = \frac{2}{n} X^\top \cdot (X\theta - Y) = 0 \implies \theta^* = (X^TX)^{-1}X^TY
 $$
 
 That's it! You can now derive the optimal solution for any linear regression problem.
@@ -406,19 +406,19 @@ where $\lambda$ is some scalar hyperparameter we can choose.
 Calculating this derivative is basically the same as last time, except there's an additional squared term at the end that we can differentiate separately. Setting the derivative with respect to $\theta$ to 0, gives:
 
 $$
-\frac{dJ}{d\theta} = \frac{2}{n} X^T \cdot (X\theta^* - Y) + 2\lambda \theta^* = 0
+\frac{dJ}{d\theta} = \frac{2}{n} X^\top \cdot (X\theta^* - Y) + 2\lambda \theta^* = 0
 $$
 
 which simplifies to:
 
 $$
-0 = X^T X\theta^* - X^T Y + n\lambda \theta^*
+0 = X^\top X\theta^* - X^\top Y + n\lambda \theta^*
 $$
 
 or
 
 $$
-\theta^* = (X^T X + n\lambda I)^{-1} X^T Y
+\theta^* = (X^\top X + n\lambda I)^{-1} X^\top Y
 $$
 
 ## Matrix Derivatives Using Einstein Summation {#app:einstein}
@@ -428,7 +428,7 @@ $$
 Consider the objective function for linear regression, written out as products of matrices:
 
 $$\begin{aligned}
-J(\theta) = \frac{1}{n} (X\theta - Y)^T (X\theta-Y)
+J(\theta) = \frac{1}{n} (X\theta - Y)^\top (X\theta-Y)
 \,,
 \end{aligned}
 $$
@@ -436,7 +436,7 @@ $$
 where $X$ is $n\times d$, $Y$ is $n\times 1$, and $\theta$ is $d\times 1$. How does one show, with no shortcuts, that
 
 $$\begin{aligned}
-\nabla_{\theta}J = \frac{2}{n} {X^T} {(X\theta - Y)} \;\;?
+\nabla_{\theta}J = \frac{2}{n} {X^\top} {(X\theta - Y)} \;\;?
 \end{aligned}
 $$
 
@@ -466,12 +466,12 @@ $$\begin{aligned}
 &=& \frac{2}{n} X_{ad} \left( X_{ab}\theta_b-Y_a \right)
 \,,
 \end{aligned}$$
-where the second line follows from the first, with the definition that $\delta_{bd} = 1$ only when $b=d$ (and similarly for $\delta_{cd}$). And the third line follows from the second by recognizing that the two terms in the second line are identical. Now note that in this implicit summation notation, the $a, b$ element of the matrix product of $A$ and $B$ is $(AB)_{ac} = A_{ab}B_{bc}$. That is, ordinary matrix multiplication sums over indices which are adjacent to each other, because a row of $A$ times a column of $B$ becomes a scalar number. So the term in the above equation with $X_{ad} X_{ab}$ is not a matrix product of $X$ with $X$. However, taking the transpose $X^T$ switches row and column indices, so $X_{ad} = X^T_{da}$. And $X^T_{da} X_{ab}$ *is* a matrix product of $X^T$ with $X$! Thus, we have that
+where the second line follows from the first, with the definition that $\delta_{bd} = 1$ only when $b=d$ (and similarly for $\delta_{cd}$). And the third line follows from the second by recognizing that the two terms in the second line are identical. Now note that in this implicit summation notation, the $a, b$ element of the matrix product of $A$ and $B$ is $(AB)_{ac} = A_{ab}B_{bc}$. That is, ordinary matrix multiplication sums over indices which are adjacent to each other, because a row of $A$ times a column of $B$ becomes a scalar number. So the term in the above equation with $X_{ad} X_{ab}$ is not a matrix product of $X$ with $X$. However, taking the transpose $X^\top$ switches row and column indices, so $X_{ad} = X^T_{da}$. And $X^T_{da} X_{ab}$ *is* a matrix product of $X^\top$ with $X$! Thus, we have that
 
 $$\begin{aligned}
 \frac{dJ}{d\theta_d} =& \frac{2}{n} X^T_{da} \left( X_{ab}\theta_b-Y_a \right)
 \\
-=& \frac{2}{n} \left[ X^T \left( X\theta-Y\right) \right]_{d}
+=& \frac{2}{n} \left[ X^\top \left( X\theta-Y\right) \right]_{d}
 \,,
 \end{aligned}
 $$ which is the desired result.

--- a/matrix_calculus.qmd
+++ b/matrix_calculus.qmd
@@ -466,10 +466,10 @@ $$\begin{aligned}
 &=& \frac{2}{n} X_{ad} \left( X_{ab}\theta_b-Y_a \right)
 \,,
 \end{aligned}$$
-where the second line follows from the first, with the definition that $\delta_{bd} = 1$ only when $b=d$ (and similarly for $\delta_{cd}$). And the third line follows from the second by recognizing that the two terms in the second line are identical. Now note that in this implicit summation notation, the $a, b$ element of the matrix product of $A$ and $B$ is $(AB)_{ac} = A_{ab}B_{bc}$. That is, ordinary matrix multiplication sums over indices which are adjacent to each other, because a row of $A$ times a column of $B$ becomes a scalar number. So the term in the above equation with $X_{ad} X_{ab}$ is not a matrix product of $X$ with $X$. However, taking the transpose $X^\top$ switches row and column indices, so $X_{ad} = X^T_{da}$. And $X^T_{da} X_{ab}$ *is* a matrix product of $X^\top$ with $X$! Thus, we have that
+where the second line follows from the first, with the definition that $\delta_{bd} = 1$ only when $b=d$ (and similarly for $\delta_{cd}$). And the third line follows from the second by recognizing that the two terms in the second line are identical. Now note that in this implicit summation notation, the $a, b$ element of the matrix product of $A$ and $B$ is $(AB)_{ac} = A_{ab}B_{bc}$. That is, ordinary matrix multiplication sums over indices which are adjacent to each other, because a row of $A$ times a column of $B$ becomes a scalar number. So the term in the above equation with $X_{ad} X_{ab}$ is not a matrix product of $X$ with $X$. However, taking the transpose $X^\top$ switches row and column indices, so $X_{ad} = X^\top_{da}$. And $X^\top_{da} X_{ab}$ *is* a matrix product of $X^\top$ with $X$! Thus, we have that
 
 $$\begin{aligned}
-\frac{dJ}{d\theta_d} =& \frac{2}{n} X^T_{da} \left( X_{ab}\theta_b-Y_a \right)
+\frac{dJ}{d\theta_d} =& \frac{2}{n} X^\top_{da} \left( X_{ab}\theta_b-Y_a \right)
 \\
 =& \frac{2}{n} \left[ X^\top \left( X\theta-Y\right) \right]_{d}
 \,,

--- a/matrix_calculus.qmd
+++ b/matrix_calculus.qmd
@@ -388,7 +388,7 @@ $$
 Now, to optimize, we set the derivative equal to 0:
 
 $$
-\frac{dJ}{d\theta} = \frac{2}{n} X^\top \cdot (X\theta - Y) = 0 \implies \theta^* = (X^TX)^{-1}X^TY
+\frac{dJ}{d\theta} = \frac{2}{n} X^\top \cdot (X\theta - Y) = 0 \implies \theta^* = (X^\top X)^{-1}X^\top Y
 $$
 
 That's it! You can now derive the optimal solution for any linear regression problem.

--- a/neural_networks.qmd
+++ b/neural_networks.qmd
@@ -175,7 +175,7 @@ Since each unit has a vector of weights and a single offset, we can think of the
 
 -   $X$, the input, is an $m \times 1$ column vector,
 
--   $Z = W^T X + W_0$, the *pre-activation*, is an $n \times
+-   $Z = W^\top X + W_0$, the *pre-activation*, is an $n \times
               1$ column vector,
 
 -   $A$, the *activation*, is an $n \times 1$ column vector,
@@ -247,7 +247,7 @@ There are many possible choices for the activation function. We will start by th
 
 What happens if we let $f$ be the identity? Then, in a network with $L$ layers (we'll leave out $W_0$ for simplicity, but keeping it wouldn't change the form of this argument), 
 $$
-A^L = {W^L}^T A^{L-1} = {W^L}^T {W^{L-1}}^T \cdots {W^1}^T X\;\;.
+A^L = {W^L}^\top A^{L-1} = {W^L}^\top {W^{L-1}}^\top \cdots {W^1}^\top X\;\;.
 $$ 
 
 So, multiplying out the weight matrices, we find that $$A^L = W^\text{total}X\;\;,$$ which is a *linear* function of $X$! Having all those layers did not change the representational capacity of the network: the non-linearity of the activation function is crucial.
@@ -633,7 +633,7 @@ Carrying out the derivatives gives:
 $$
 \begin{align*}
 \frac{\partial \mathcal{L}}{\partial W^1}
-&= A^0 \Big( \underbrace{{f^1}'(Z^1) \big(w^2 {f^2}'(z^2) \tfrac{\partial \mathcal L}{\partial g}\big)}_{\tfrac{\partial \mathcal L}{\partial Z^1}}\Big)^T
+&= A^0 \Big( \underbrace{{f^1}'(Z^1) \big(w^2 {f^2}'(z^2) \tfrac{\partial \mathcal L}{\partial g}\big)}_{\tfrac{\partial \mathcal L}{\partial Z^1}}\Big)^\top
 \end{align*}
 $$
 
@@ -998,7 +998,7 @@ $$
   &=
   \underbrace{A^{l-1}}_{m^l \times 1} \;
   \underbrace{\left(\frac{\partial \text{loss}}{\partial
-      Z^l}\right)^T}_{1 \times n^l} \\
+      Z^l}\right)^\top}_{1 \times n^l} \\
 \end{aligned}
 $${#eq-gradloss}
 
@@ -1214,7 +1214,7 @@ Which terms in the code below depend on $f^L$?
     \State $i \gets \text{random sample from } \{1,\ldots,n\}$
     \State $A^0 \gets x^{(i)}$  \Comment{forward pass to compute $A^L$}
     \For{$l \gets 1$ to $L$}
-      \State $Z^l \gets W^{l^T} A^{l-1} + W_0^l$
+      \State $Z^l \gets W^{l^\top} A^{l-1} + W_0^l$
       \State $A^l \gets f^l(Z^l)$
     \EndFor
 

--- a/neural_networks.qmd
+++ b/neural_networks.qmd
@@ -186,7 +186,7 @@ and the output vector is $$A = f(Z) = f(W^TX + W_0)\;\;.$$ The activation functi
 
 A single neural network generally combines multiple layers, most typically by feeding the outputs of one layer into the inputs of another layer.
 
-We have to start by establishing some nomenclature. We will use $l$ to name a layer, and let $m^l$ be the number of inputs to the layer and $n^l$ be the number of outputs from the layer. Then, $W^l$ and $W^l_0$ are of shape $m^l \times n^l$ and $n^l \times 1$, respectively. Note that the input to layer $l$ is the output from layer $l-1$, so we have $m^l= n^{l-1}$, and as a result $A^{l-1}$ is of shape $m^l \times 1$, or equivalently $n^{l-1} \times 1$. Let $f^l$ be the activation function of layer $l$. Then, the pre-activation outputs are the $n^l \times 1$ vector $$Z^l = {W^l}^TA^{l-1} + W^l_0$$ and the activation outputs are simply the $n^l \times 1$ vector 
+We have to start by establishing some nomenclature. We will use $l$ to name a layer, and let $m^l$ be the number of inputs to the layer and $n^l$ be the number of outputs from the layer. Then, $W^l$ and $W^l_0$ are of shape $m^l \times n^l$ and $n^l \times 1$, respectively. Note that the input to layer $l$ is the output from layer $l-1$, so we have $m^l= n^{l-1}$, and as a result $A^{l-1}$ is of shape $m^l \times 1$, or equivalently $n^{l-1} \times 1$. Let $f^l$ be the activation function of layer $l$. Then, the pre-activation outputs are the $n^l \times 1$ vector $$Z^l = {W^l}^\top A^{l-1} + W^l_0$$ and the activation outputs are simply the $n^l \times 1$ vector 
 $$
 A^l = f^l(Z^l)\;\;.
 $$

--- a/neural_networks.qmd
+++ b/neural_networks.qmd
@@ -180,7 +180,7 @@ Since each unit has a vector of weights and a single offset, we can think of the
 
 -   $A$, the *activation*, is an $n \times 1$ column vector,
 
-and the output vector is $$A = f(Z) = f(W^TX + W_0)\;\;.$$ The activation function $f$ is applied element-wise to the pre-activation values $Z$.
+and the output vector is $$A = f(Z) = f(W^\top X + W_0)\;\;.$$ The activation function $f$ is applied element-wise to the pre-activation values $Z$.
 
 ### Many layers
 

--- a/regression.qmd
+++ b/regression.qmd
@@ -110,7 +110,7 @@ To make this discussion more concrete, we need to provide a hypothesis class and
 
 We begin by picking a class of hypotheses $\mathcal{H}$ that might provide a good set of possible models for the relationship between $x$ and $y$ in our data. We start with a very simple class of *linear* hypotheses for regression:
 $$
-y = h(x; \theta, \theta_0) = \theta^T x + \theta_0 \;\;,
+y = h(x; \theta, \theta_0) = \theta^\top x + \theta_0 \;\;,
 $${#eq-linear_reg_hypothesis}
 
 where the model parameters are $\Theta = (\theta, \theta_0)$. In one dimension ($d = 1$), this corresponds to the familiar slope-intercept form $y = mx + b$ of a *line*. In two dimensions ($d = 2$), this corresponds to a *plane*. In higher dimensions, this model describes a *hyperplane*. This hypothesis class is both simple to study and very powerful, and will serve as the basis for many other important techniques (even neural networks!).
@@ -196,7 +196,7 @@ One very interesting aspect of the problem of finding a linear hypothesis that m
 
 Everything is easier to deal with if we first *ignore* the offset $\theta_0$. So, suppose for now, we have, simply, 
 $$
-y = \theta^T x\;\;.
+y = \theta^\top x\;\;.
 $${#eq-linear_reg_hypothesis_noconst}
  
 :::{.column-margin}
@@ -244,14 +244,14 @@ What are the dimensions of $X$ and $Y$?
 :::
 
 Now we can write 
-$$J(\theta) = \frac{1}{n} \sum_{i=1}^n (\theta^T x^{(i)} - y^{(i)})^2 =  \frac{1}{n} (X \theta - Y)^T(X \theta - Y).$$
+$$J(\theta) = \frac{1}{n} \sum_{i=1}^n (\theta^\top x^{(i)} - y^{(i)})^2 =  \frac{1}{n} (X \theta - Y)^\top(X \theta - Y).$$
 
 and using facts about matrix/vector calculus, we get 
 
 $$
 \begin{align*}
-\nabla_{\theta} J(\theta) &= \frac{1}{n} \nabla_{\theta} \left[ (X \theta)^T X \theta - Y^T X \theta - (X \theta)^T Y + Y^T Y  \right] \\
-&= \frac{2}{n} \left( X^T X \theta - X^T Y\right).
+\nabla_{\theta} J(\theta) &= \frac{1}{n} \nabla_{\theta} \left[ (X \theta)^\top X \theta - Y^\top X \theta - (X \theta)^\top Y + Y^\top Y  \right] \\
+&= \frac{2}{n} \left( X^\top X \theta - X^\top Y\right).
 \end{align*}
 $$
 
@@ -262,16 +262,16 @@ See @sec-matrix-calculus if you need some help finding this gradient.
 Setting this equal to zero and solving for $\theta$ yields the final closed-form solution:
 
 $$
-\theta^* = \left(X^T X\right)^{-1} X^T Y
+\theta^* = \left(X^\top X\right)^{-1} X^\top Y
 $${#eq-ols_solution}
 
 :::{.column-margin}
 Here are two related alternate angles to view this formula, for intuition's sake:
 
-1) Note that $(X^TX)^{-1}X^T \eqqcolon X^+$ is the [pseudo-inverse](https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Linearly_independent_columns) of $X$. 
+1) Note that $(X^TX)^{-1}X^\top \eqqcolon X^+$ is the [pseudo-inverse](https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Linearly_independent_columns) of $X$. 
 Thus, $\theta^*$ "pseudo-solves" $X\theta=Y$ (multiply both sides of this on the left by $X^+$).
 
-2) Note that $X(X^TX)^{-1}X^T = \text{proj}_{\text{col}(X)}$ is the [projection matrix](https://en.wikipedia.org/wiki/Projection_matrix#Intuition) onto the column space of $X$.
+2) Note that $X(X^TX)^{-1}X^\top = \text{proj}_{\text{col}(X)}$ is the [projection matrix](https://en.wikipedia.org/wiki/Projection_matrix#Intuition) onto the column space of $X$.
 Thus, $\theta^*$ solves $X\theta=\text{proj}_{\text{col}(X)}Y$.
 :::
 
@@ -305,7 +305,7 @@ where the "aug" denotes that $\theta, x$ have been augmented.
 Then we can now write the linear hypothesis **as if** there is no offset,
 
 $$
-y = h(x_{\text{aug}}; \theta_{\text{aug}}) = \theta_{\text{aug}}^T x_{\text{aug}} \;\;
+y = h(x_{\text{aug}}; \theta_{\text{aug}}) = \theta_{\text{aug}}^\top x_{\text{aug}} \;\;
 $${#eq-linear_reg_hypothesis_augmented}
 
 :::{.column-margin}
@@ -333,16 +333,16 @@ The idea is that, with centered dataset, even if we were to search for an offset
 
 Let's see how this works out mathematically. First, for a *centered* dataset, two claims immediately follow  (recall that $\mathbb{1}$ is an $n$-by-1 vector of all ones):
 
-1. Each column of $X$ sums up to zero, that is, $X^T\mathbb{1} = 0$.
+1. Each column of $X$ sums up to zero, that is, $X^\top\mathbb{1} = 0$.
 
-2. Similarly, the mean of the labels is 0, so $Y^T\mathbb{1} = \mathbb{1} ^T Y = 0$.
+2. Similarly, the mean of the labels is 0, so $Y^\top\mathbb{1} = \mathbb{1} ^\top Y = 0$.
 
 Recall that our ultimate goal is to find an optimal fitting hyperplane, parameterized by $\theta$ and $\theta_0$. In other words, we aim to find $\theta_{\text{aug}},$ which at this point, involves simply plugging $X_{\text{aug}}=\left[\begin{array}{c}X \quad  \mathbb{1} \end{array}\right]$ into @eq-ols_solution. 
 
 $$\begin{aligned}
-\theta_{\text{aug}}^*&=\left ( \begin{bmatrix} X^T\\\mathbb{1}^T\end{bmatrix}\begin{bmatrix}X&\mathbb{1}\end{bmatrix}\right)^{-1}\begin{bmatrix}X^T\\ \mathbb{1}^T\end{bmatrix}Y\\
-&=\begin{bmatrix}X^TX&X^T\mathbb{1}\\\mathbb{1}^TX&\mathbb{1}^T\mathbb{1}\end{bmatrix}^{-1}\begin{bmatrix}X^T\\ \mathbb{1}^T\end{bmatrix}Y\\
-&=\begin{bmatrix}X^TX&0\\0&n\end{bmatrix}^{-1}\begin{bmatrix}X^T\\\mathbb{1}^T\end{bmatrix}Y\\
+\theta_{\text{aug}}^*&=\left ( \begin{bmatrix} X^\top\\\mathbb{1}^\top\end{bmatrix}\begin{bmatrix}X&\mathbb{1}\end{bmatrix}\right)^{-1}\begin{bmatrix}X^\top\\ \mathbb{1}^\top\end{bmatrix}Y\\
+&=\begin{bmatrix}X^TX&X^\top\mathbb{1}\\\mathbb{1}^TX&\mathbb{1}^\top\mathbb{1}\end{bmatrix}^{-1}\begin{bmatrix}X^\top\\ \mathbb{1}^\top\end{bmatrix}Y\\
+&=\begin{bmatrix}X^TX&0\\0&n\end{bmatrix}^{-1}\begin{bmatrix}X^\top\\\mathbb{1}^\top\end{bmatrix}Y\\
 &=\begin{bmatrix}(X^TX)^{-1}X^TY\\\frac{1}{n}\mathbb{1}^TY\end{bmatrix}\\
 &=\begin{bmatrix}(X^TX)^{-1}X^TY\\0\end{bmatrix}\\
 &=\begin{bmatrix}\theta^*\\\theta_0^*\end{bmatrix}\\
@@ -361,7 +361,7 @@ The objective function of @eq-ml_objective_loss balances (training-data) memoriz
 
 If all we cared about was finding a hypothesis with small loss on the training data, we would have no need for regularization, and could simply omit the second term in the objective. But remember that our ultimate goal is to *perform well on input values that we haven't trained on!* It may seem that this is an impossible task, but humans and machine-learning methods do this successfully all the time. What allows *generalization* to new input values is a belief that there is an underlying regularity that governs both the training and testing data. One way to describe an assumption about such a regularity is by choosing a limited class of possible hypotheses. Another way to do this is to provide smoother guidance, saying that, within a hypothesis class, we prefer some hypotheses to others. The regularizer articulates this preference and the constant $\lambda$ says how much we are willing to trade off loss on the training data versus preference over hypotheses.
 
-For example, consider what happens when $d=2,$ and $x_2$ is highly correlated with $x_1$, meaning that the data look like a line, as shown in the left panel of the figure below. Thus, there are many hyperplanes that can achieve more or less the same training MSE. Such correlations happen often in real-life data, because of underlying common causes; for example, across a population, the height of people may depend on both age and amount of food intake in the same way. This is especially the case when there are many feature dimensions used in the regression. Mathematically, this leads to ${X}^T{X}$ close to singularity, such that $({X}^T{X})^{-1}$ is undefined or has huge values, resulting in unstable models (see the middle panel of figure and note the range of the $y$ values---the slope is huge!):
+For example, consider what happens when $d=2,$ and $x_2$ is highly correlated with $x_1$, meaning that the data look like a line, as shown in the left panel of the figure below. Thus, there are many hyperplanes that can achieve more or less the same training MSE. Such correlations happen often in real-life data, because of underlying common causes; for example, across a population, the height of people may depend on both age and amount of food intake in the same way. This is especially the case when there are many feature dimensions used in the regression. Mathematically, this leads to ${X}^\top{X}$ close to singularity, such that $({X}^\top{X})^{-1}$ is undefined or has huge values, resulting in unstable models (see the middle panel of figure and note the range of the $y$ values---the slope is huge!):
 
 ![](figures/regression_ex2_plane1.png){width="100%"}
 
@@ -377,11 +377,11 @@ $$R(\Theta) = \left\lVert\Theta\right\rVert^2\;\;.$$
 
 ### Ridge regression {#sec-ridge_regression}
 
-There are some kinds of trouble we can get into in regression problems. What if $\left({X}^T{X}\right)$ is not invertible?
+There are some kinds of trouble we can get into in regression problems. What if $\left({X}^\top{X}\right)$ is not invertible?
 
 Another kind of problem is *overfitting*: we have formulated an objective that is just about fitting the data as well as possible, but we might also want to *regularize* to keep the hypothesis from getting *too* attached to the data.
 
-We address both the problem of not being able to invert ${X}^T{X}$ and the problem of overfitting using a mechanism called *ridge regression*. We add a regularization term $\|\theta\|^2$ to the OLS objective, with a non-negative scalar value $\lambda$ to control the tradeoff between the training error and the regularization term. Here is the ridge regression objective function: 
+We address both the problem of not being able to invert ${X}^\top{X}$ and the problem of overfitting using a mechanism called *ridge regression*. We add a regularization term $\|\theta\|^2$ to the OLS objective, with a non-negative scalar value $\lambda$ to control the tradeoff between the training error and the regularization term. Here is the ridge regression objective function: 
 
 $$
 J_{\text{ridge}}(\theta, \theta_0) = \frac{1}{n}\sum_{i = 1}^n\left(\theta^Tx^{(i)} + \theta_0 - y^{(i)}\right)^2 + \lambda\|\theta\|^2
@@ -405,30 +405,30 @@ Compare @eq-uncentered_ridge_objective and @eq-centered_ridge_objective. What is
 
 and the solution is: 
 $$
-\theta_{\text{ridge}} = \left({X}^T{X}+ n\lambda I\right)^{-1}{X}^T{Y}
+\theta_{\text{ridge}} = \left({X}^\top{X}+ n\lambda I\right)^{-1}{X}^\top{Y}
 $${#eq-ridge_regression_solution}
 
 
 
 :::{.callout-note collapse="true"}
 ## Derivation of the Ridge Regression Solution for Centered Data Set
-$$\nabla_{\theta}J_\text{ridge} = \frac{2}{n}{X}^T({X}\theta - {Y}) + 2
+$$\nabla_{\theta}J_\text{ridge} = \frac{2}{n}{X}^\top({X}\theta - {Y}) + 2
   \lambda \theta\;\;.$${#eq-regularized-solution}
 
 
 Setting to 0 and solving, we get: 
 $$\begin{aligned}
-  \frac{2}{n}{X}^T({X}\theta - {Y}) + 2 \lambda \theta             & = 0                                      \\
-  \frac{1}{n}{X}^T{X}\theta - \frac{1}{n}{X}^T{Y}+ \lambda \theta & = 0                                      \\
-  \frac{1}{n}{X}^T{X}\theta  + \lambda \theta                      & = \frac{1}{n}{X}^T{Y}\\
-  {X}^T{X}\theta  + n \lambda \theta                               & = {X}^T{Y}\\
-  ({X}^T{X}+ n \lambda I)\theta                                  & = {X}^T{Y}\\
-  \theta                                                           & = ({X}^T{X}+ n \lambda I)^{-1}{X}^T{Y}
+  \frac{2}{n}{X}^\top({X}\theta - {Y}) + 2 \lambda \theta             & = 0                                      \\
+  \frac{1}{n}{X}^\top{X}\theta - \frac{1}{n}{X}^\top{Y}+ \lambda \theta & = 0                                      \\
+  \frac{1}{n}{X}^\top{X}\theta  + \lambda \theta                      & = \frac{1}{n}{X}^\top{Y}\\
+  {X}^\top{X}\theta  + n \lambda \theta                               & = {X}^\top{Y}\\
+  ({X}^\top{X}+ n \lambda I)\theta                                  & = {X}^\top{Y}\\
+  \theta                                                           & = ({X}^\top{X}+ n \lambda I)^{-1}{X}^\top{Y}
 \end{aligned}$$
 :::
 
 
-One other great news is that in @eq-regularized-solution, the matrix we are trying to invert can always be inverted! Why is the term $\left({X}^T{X}+ n\lambda I\right)$ invertible? Explaining this requires some linear algebra. The matrix ${X}^T{X}$ is positive semidefinite, which implies that its eigenvalues $\{\gamma_i\}_i$ are greater than or equal to 0. The matrix ${X}^T{X}+n\lambda I$ has eigenvalues $\{\gamma_i+n\lambda\}_i$ which are guaranteed to be strictly positive since $\lambda>0$. Recalling that the determinant of a matrix is simply the product of its eigenvalues, we get that $\det({X}^T{X}+ n\lambda I)>0$ and conclude that ${X}^T{X}+ n\lambda I$ is invertible.
+One other great news is that in @eq-regularized-solution, the matrix we are trying to invert can always be inverted! Why is the term $\left({X}^\top{X}+ n\lambda I\right)$ invertible? Explaining this requires some linear algebra. The matrix ${X}^\top{X}$ is positive semidefinite, which implies that its eigenvalues $\{\gamma_i\}_i$ are greater than or equal to 0. The matrix ${X}^\top{X}+n\lambda I$ has eigenvalues $\{\gamma_i+n\lambda\}_i$ which are guaranteed to be strictly positive since $\lambda>0$. Recalling that the determinant of a matrix is simply the product of its eigenvalues, we get that $\det({X}^\top{X}+ n\lambda I)>0$ and conclude that ${X}^\top{X}+ n\lambda I$ is invertible.
 
 ## Evaluating learning algorithms {#sec-reg_learn_alg}
 

--- a/regression.qmd
+++ b/regression.qmd
@@ -341,10 +341,10 @@ Recall that our ultimate goal is to find an optimal fitting hyperplane, paramete
 
 $$\begin{aligned}
 \theta_{\text{aug}}^*&=\left ( \begin{bmatrix} X^\top\\\mathbb{1}^\top\end{bmatrix}\begin{bmatrix}X&\mathbb{1}\end{bmatrix}\right)^{-1}\begin{bmatrix}X^\top\\ \mathbb{1}^\top\end{bmatrix}Y\\
-&=\begin{bmatrix}X^TX&X^\top\mathbb{1}\\\mathbb{1}^TX&\mathbb{1}^\top\mathbb{1}\end{bmatrix}^{-1}\begin{bmatrix}X^\top\\ \mathbb{1}^\top\end{bmatrix}Y\\
-&=\begin{bmatrix}X^TX&0\\0&n\end{bmatrix}^{-1}\begin{bmatrix}X^\top\\\mathbb{1}^\top\end{bmatrix}Y\\
-&=\begin{bmatrix}(X^TX)^{-1}X^TY\\\frac{1}{n}\mathbb{1}^TY\end{bmatrix}\\
-&=\begin{bmatrix}(X^TX)^{-1}X^TY\\0\end{bmatrix}\\
+&=\begin{bmatrix}X^\top X&X^\top\mathbb{1}\\\mathbb{1}^\top X&\mathbb{1}^\top\mathbb{1}\end{bmatrix}^{-1}\begin{bmatrix}X^\top\\ \mathbb{1}^\top\end{bmatrix}Y\\
+&=\begin{bmatrix}X^\top X&0\\0&n\end{bmatrix}^{-1}\begin{bmatrix}X^\top\\\mathbb{1}^\top\end{bmatrix}Y\\
+&=\begin{bmatrix}(X^\top X)^{-1}X^\top Y\\\frac{1}{n}\mathbb{1}^\top Y\end{bmatrix}\\
+&=\begin{bmatrix}(X^\top X)^{-1}X^\top Y\\0\end{bmatrix}\\
 &=\begin{bmatrix}\theta^*\\\theta_0^*\end{bmatrix}\\
 \end{aligned}
 $$

--- a/regression.qmd
+++ b/regression.qmd
@@ -268,10 +268,10 @@ $${#eq-ols_solution}
 :::{.column-margin}
 Here are two related alternate angles to view this formula, for intuition's sake:
 
-1) Note that $(X^TX)^{-1}X^\top \eqqcolon X^+$ is the [pseudo-inverse](https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Linearly_independent_columns) of $X$. 
+1) Note that $(X^\top X)^{-1}X^\top \eqqcolon X^+$ is the [pseudo-inverse](https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Linearly_independent_columns) of $X$. 
 Thus, $\theta^*$ "pseudo-solves" $X\theta=Y$ (multiply both sides of this on the left by $X^+$).
 
-2) Note that $X(X^TX)^{-1}X^\top = \text{proj}_{\text{col}(X)}$ is the [projection matrix](https://en.wikipedia.org/wiki/Projection_matrix#Intuition) onto the column space of $X$.
+2) Note that $X(X^\top X)^{-1}X^\top = \text{proj}_{\text{col}(X)}$ is the [projection matrix](https://en.wikipedia.org/wiki/Projection_matrix#Intuition) onto the column space of $X$.
 Thus, $\theta^*$ solves $X\theta=\text{proj}_{\text{col}(X)}Y$.
 :::
 

--- a/representation.qmd
+++ b/representation.qmd
@@ -114,10 +114,10 @@ Another approach to learning representations without labels relies on *co-occurr
 
 Semantically related words such as "dog" and "cat" should have vectors close together, while unrelated words like "cat" and "table" should be farther apart. Similarity between embeddings is frequently measured using the *inner product* (dot product):
 
-$$a^T b = a \cdot b = \sum_{j} a_j \, b_j$$
+$$a^\top b = a \cdot b = \sum_{j} a_j \, b_j$$
 
 :::{.column-margin}
-A related measure is *cosine similarity*, $\frac{a^T b}{\|a\| \, \|b\|}$, which normalizes for vector magnitude and measures only directional alignment.
+A related measure is *cosine similarity*, $\frac{a^\top b}{\|a\| \, \|b\|}$, which normalizes for vector magnitude and measures only directional alignment.
 :::
 
 The inner product indicates how aligned two vectors are: highly positive values imply strong similarity, negative values indicate opposition, and values near zero suggest no similarity (up to a scaling factor related to the magnitude).
@@ -179,8 +179,8 @@ Assume that we have input data $\mathcal{D} = \{x^{(1)}, \ldots,
   \mathbb{R}^k$, and a *decoder* $h : \mathbb{R}^k \rightarrow
   \mathbb{R}^d$ that maps the representation space back into the original data space.
 
-The encoder and decoder are typically neural networks. The basic architecture of a single-layer autoencoder is shown in @fig-autoencoder; note that bias terms $W^1_0$ and $W^2_0$ into the summation nodes exist, but are omitted for clarity in the figure. The original $d$-dimensional input is compressed into $k$ dimensions via the encoder $g(x; W^1, W^1_0)=f_1(W{^1}^T x + W^1_0)$ with $W^1 \in
-  \mathbb{R}^{d \times k}$ and $W^1_0 \in \mathbb{R}^k$, where the non-linearity $f_1$ is applied element-wise. To recover (an approximation to) the original instance, we then apply the decoder $h(a; W^2, W^2_0) = f_2(W{^2}^T
+The encoder and decoder are typically neural networks. The basic architecture of a single-layer autoencoder is shown in @fig-autoencoder; note that bias terms $W^1_0$ and $W^2_0$ into the summation nodes exist, but are omitted for clarity in the figure. The original $d$-dimensional input is compressed into $k$ dimensions via the encoder $g(x; W^1, W^1_0)=f_1(W{^1}^\top x + W^1_0)$ with $W^1 \in
+  \mathbb{R}^{d \times k}$ and $W^1_0 \in \mathbb{R}^k$, where the non-linearity $f_1$ is applied element-wise. To recover (an approximation to) the original instance, we then apply the decoder $h(a; W^2, W^2_0) = f_2(W{^2}^\top
   a + W^2_0)$, where $f_2$ denotes a different activation function. In general, both the encoder and decoder could involve multiple layers. Learning seeks parameters $W^1, W^1_0$ and $W^2, W^2_0$ such that the reconstructed instances, $h(g(x^{(i)}; W^{1}, W^1_0); W^{2}, W^2_0)$, are close to the original input $x^{(i)}$.
 
 ![Autoencoder structure, showing the encoder (left half, light green), and the decoder (right half, light blue), encoding inputs $x$ to the representation $a$, and decoding the representation to produce $\tilde{x}$, the reconstruction. In this specific example, the representation ($a_1$, $a_2$, $a_3$) only has three dimensions.](figures/autoencoder.png){#fig-autoencoder width="60%"}

--- a/rnn.qmd
+++ b/rnn.qmd
@@ -295,17 +295,17 @@ The **BPTT** process goes as follows:
    and
 
    \[
-   \frac{\partial s_t}{\partial s_{t-1}} = \frac{\partial z_t^1}{\partial s_{t-1}}\,\frac{\partial s_t}{\partial z_t^1} = {W^{ss}}^T\,\frac{\partial s_t}{\partial z_t^1}.
+   \frac{\partial s_t}{\partial s_{t-1}} = \frac{\partial z_t^1}{\partial s_{t-1}}\,\frac{\partial s_t}{\partial z_t^1} = {W^{ss}}^\top\,\frac{\partial s_t}{\partial z_t^1}.
    \]
 
    ::: {.example}
-   Note that \(\frac{\partial s_t}{\partial z_t^1}\) is formally an \(m \times m\) diagonal matrix whose diagonal entries are \(f_s'(z_{t,i}^1)\) for \(1\le i\le m\). Often, we represent this diagonal matrix as an \(m \times 1\) vector \(f_s'(z_t^1)\). In that case, the product \({W^{ss}}^T * f_s'(z_t^1)\) should be interpreted as multiplying each column of \({W^{ss}}^T\) by the corresponding entry of \(f_s'(z_t^1)\).
+   Note that \(\frac{\partial s_t}{\partial z_t^1}\) is formally an \(m \times m\) diagonal matrix whose diagonal entries are \(f_s'(z_{t,i}^1)\) for \(1\le i\le m\). Often, we represent this diagonal matrix as an \(m \times 1\) vector \(f_s'(z_t^1)\). In that case, the product \({W^{ss}}^\top * f_s'(z_t^1)\) should be interpreted as multiplying each column of \({W^{ss}}^\top\) by the corresponding entry of \(f_s'(z_t^1)\).
    :::
 
    Putting everything together, we obtain
 
    \[
-   \delta^{s_{t-1}} = {W^{ss}}^T\,\frac{\partial s_t}{\partial z_t^1}\,\Bigl({W^o}^T\,\frac{\partial \mathcal{L}_t}{\partial z_t^2} + \delta^{s_t}\Bigr).
+   \delta^{s_{t-1}} = {W^{ss}}^\top\,\frac{\partial s_t}{\partial z_t^1}\,\Bigl({W^o}^\top\,\frac{\partial \mathcal{L}_t}{\partial z_t^2} + \delta^{s_t}\Bigr).
    \]
 
    The gradients for the weight matrices are then given by
@@ -326,7 +326,7 @@ The **BPTT** process goes as follows:
    Assuming \(\frac{\partial \mathcal{L}_t}{\partial z_t^2} = (g_t - y_t)\) (which holds for squared loss, softmax-NLL, etc.), then
 
    \[
-   \frac{d \mathcal{L}_\text{seq}}{d W^o} = \sum_{t=1}^n (g_t - y_t)\, s_t^T.
+   \frac{d \mathcal{L}_\text{seq}}{d W^o} = \sum_{t=1}^n (g_t - y_t)\, s_t^\top.
    \]
 
    Whew!

--- a/transformers.qmd
+++ b/transformers.qmd
@@ -64,7 +64,7 @@ Our goal is for each input token to learn how much attention it should give to e
 A token's query vector $q_i$ is computed by multiplying the input token $x_i$ (a $d$-dimensional vector) by a learnable query weight matrix $W_q$ (of dimension $d \times d_k$, $d_k$ is a hyperparameter typically chosen such that $d_k < d$):
 
 $$
-q_i = W_q^T x_i
+q_i = W_q^\top x_i
 $$
 
 Thus, for a sequence of $n$ tokens, we generate $n$ distinct query vectors.
@@ -74,13 +74,13 @@ Thus, for a sequence of $n$ tokens, we generate $n$ distinct query vectors.
 To complement query vectors, we introduce **key vectors**, which tokens use to "answer" queries about their relevance. Specifically, when evaluating token $x_3$, its query vector $q_3$ is compared to each token's key vector $k_j$ to determine the attention weight. Each key vector $k_i$ is computed similarly using a learnable key weight matrix $W_k$:
 
 $$
-k_i = W_k^T x_i
+k_i = W_k^\top x_i
 $$
 
 The attention mechanism calculates similarity using the dot product, which efficiently measures vector similarity:
 
 $$
-a_i = \text{softmax}\left(\frac{[q_i^T k_1, q_i^T k_2, \dots, q_i^T k_n]}{\sqrt{d_k}}\right) \in \mathbb{R}^{1\times n}
+a_i = \text{softmax}\left(\frac{[q_i^\top k_1, q_i^\top k_2, \dots, q_i^\top k_n]}{\sqrt{d_k}}\right) \in \mathbb{R}^{1\times n}
 $$
 
 The vector $a_i$ (softmax'd attention scores) quantifies how much attention token $q_i$ should pay to each token in the sequence, normalized so that elements sum to 1. Normalizing by $\sqrt{d_k}$ prevents large dot-product magnitudes, stabilizing training.
@@ -90,7 +90,7 @@ The vector $a_i$ (softmax'd attention scores) quantifies how much attention toke
 To incorporate meaningful contributions from attended tokens, we use **value vectors** ($v_i$), providing distinct representations for contribution to attention outputs. Each token's value vector is computed with another learnable matrix $W_v$:
 
 $$
-v_i = W_v^T x_i
+v_i = W_v^\top x_i
 $$
 
 ### Attention Output


### PR DESCRIPTION
## Summary
- Replace `^T` with `^\top` in all `.qmd` files for consistent rendering across the book.
- Previously mixed: most chapters used `^T`; `transformers.qmd` (4 T / 23 top) and `neural_networks.qmd` (5 T / 14 top) mixed both. `\top` renders as an upright glyph, visually distinct from variable `T`.
- One intentional skip: `neural_network_appendix.qmd:22` — `\sum_{t=1}^T` is a sum upper limit, not a transpose.

## Stats
11 files, 113 lines each side (pure replacement).

## Test plan
- [x] `quarto render --to html` completes without errors
- [x] Spot-check rendered math in `transformers.qmd`, `regression.qmd`, `matrix_calculus.qmd`
- [x] Confirm `neural_network_appendix.qmd` sum still renders as `T`