### PR TITLE
Polish regression chapter

### DIFF
--- a/regression.qmd
+++ b/regression.qmd
@@ -27,11 +27,11 @@ $$h: \mathbb{R}^d \rightarrow \mathbb{R} \;\;.$$
  This is a good framework when we want to predict a numerical quantity, like height, stock value, etc., rather than to divide the inputs into discrete categories. For example, $x^{(i)}$ might represent the size of a house and $y^{(i)}$ its sale price.
 
 :::{.column-margin}
-Real life rarely gives us vectors of real numbers. The $x$ we really want to take as input is usually something like a song, image, or person. In that case, we'll have to define a function $\varphi(x)$ whose range is $\mathbb{R}^d$, where $\varphi$ represents *features* of $x$ (e.g., a person's height or the amount of bass in a song).
+Real life rarely gives us vectors of real numbers. The $x$ we really want to take as input is usually something like a song, image, or person. In that case, we'll have to define a function $\phi(x)$ whose range is $\mathbb{R}^d$, where $\phi$ represents *features* of $x$ (e.g., a person's height or the amount of bass in a song).
 
-This process of converting our data into a numerical form is often referred to as *data pre-processing*.  Then $h$ maps $\varphi(x)$ to $\mathbb{R}$. 
+This process of converting our data into a numerical form is often referred to as *data pre-processing*.  Then $h$ maps $\phi(x)$ to $\mathbb{R}$. 
 
-In much of the following, we'll omit explicit mention of $\varphi$ and assume that the $x^{(i)}$ are in $\mathbb{R}^d$. However, you should always remember that some additional process was almost surely required to go from the actual input examples to their feature representation. We will discuss features more later in the course.
+In much of the following, we'll omit explicit mention of $\phi$ and assume that the $x^{(i)}$ are in $\mathbb{R}^d$. However, you should always remember that some additional process was almost surely required to go from the actual input examples to their feature representation. We will discuss features more later in the course.
 :::
 
 
@@ -118,9 +118,9 @@ where the model parameters are $\Theta = (\theta, \theta_0)$. In one dimension (
  
 For now, our objective in linear regression is to find a hypothesis that goes as close as possible, on average, to all of our training data. We define a *loss function* to describe how to evaluate the quality of the predictions our hypothesis is making, when compared to the "target" $y$ values in the data set. The choice of loss function is part of modeling your domain. In the absence of additional information about a regression problem, we typically use *squared loss*: 
 $$
-\mathcal{L}(g, a) = (g - a)^2\;\;.
+\mathcal{L}(g, a) = (g - a)^2\;\;,
 $$
-where $g=h(x)$ is our "guess" from the hypothesis, or the hypothesis' prediction, and $a$ is the "actual" observation (in other words, here $a$ is being used equivalently as $y$). With this choice of squared loss, the average loss as generally defined in @eq-erm will become the so-called *mean squared error (MSE)*.
+where $g=h(x)$ is our "guess" from the hypothesis, or the hypothesis' prediction, and $a$ is the "actual" observation (in other words, here $a$ is being used interchangeably with $y$). With this choice of squared loss, the average loss as generally defined in @eq-erm will become the so-called *mean squared error (MSE)*.
 
 
 Applying the general optimization framework to the linear regression hypothesis class of @eq-linear_reg_hypothesis with squared loss and no regularization, our objective is to find values for $\Theta = (\theta, \theta_0)$ that minimize the MSE: 
@@ -163,16 +163,17 @@ Okay! Given the objective in @eq-reg_mse_withconst, how can we find good values 
 #| html-no-end: false
 #| pdf-placement: "htb!"
 #| pdf-line-number: true
+#| label: Random-Regression
 
 \begin{algorithm}
     \caption{Random-Regression}
     \begin{algorithmic}[1]
         \REQUIRE Data $\mathcal D$, integer $k$
         \FOR{$i = 1$ \TO $k$}
-            \STATE Randomly generate hypothesis $\theta_{i}, \theta_{0}(i)$
+            \STATE Randomly generate hypothesis $\theta^{(i)}, \theta_0^{(i)}$
         \ENDFOR
-        \STATE Let $i = \arg\min_{j} J(\theta_{(j)}, \theta_{0}(j); \mathcal D)$
-        \RETURN $\theta(i), \theta_{0}(i)$
+        \STATE Let $j^* = \arg\min_{j} J(\theta^{(j)}, \theta_0^{(j)}; \mathcal D)$
+        \RETURN $\theta^{(j^*)}, \theta_0^{(j^*)}$
     \end{algorithmic}
 \end{algorithm}
 ```
@@ -192,7 +193,7 @@ How do you think increasing the number of guesses $k$ will change the training
 
 ## Analytical solution: ordinary least squares
 
-One very interesting aspect of the problem of finding a linear hypothesis that minimizes mean squared error is that we can find a closed-form formula for the answer! This general problem is often called the *ordinary least squares* (OLS).
+One very interesting aspect of the problem of finding a linear hypothesis that minimizes mean squared error is that we can find a closed-form formula for the answer! This general problem is often called *ordinary least squares* (OLS).
 
 Everything is easier to deal with if we first *ignore* the offset $\theta_0$. So, suppose for now, we have, simply, 
 $$
@@ -213,11 +214,11 @@ We approach this just like a minimization problem from calculus homework: take t
 
 -   Finding $\partial{J}/\partial{\theta_k}$ for $k$ in $1, \ldots, d$,
 
--   Constructing a set of $k$ equations of the form $\partial{J}/\partial{\theta_k} = 0$, and
+-   Constructing a set of $d$ equations of the form $\partial{J}/\partial{\theta_k} = 0$, and
 
 -   Solving the system for values of $\theta_k$.
 
-That works just fine. To get practice for applying techniques like this to more complex problems, we will work through a more compact (and cool!) matrix view. Along the way, it will be helpful to collect all of the derivatives in one vector. In particular, the gradient of $J$ with respect to $\theta$ is following column vector of length $d$: 
+That works just fine. To get practice for applying techniques like this to more complex problems, we will work through a more compact (and cool!) matrix view. Along the way, it will be helpful to collect all of the derivatives in one vector. In particular, the gradient of $J$ with respect to $\theta$ is the following column vector of length $d$: 
 
 $$\nabla_\theta J =
   \begin{bmatrix}
@@ -244,7 +245,7 @@ What are the dimensions of $X$ and $Y$?
 :::
 
 Now we can write 
-$$J(\theta) = \frac{1}{n} \sum_{i=1}^n (\theta^T x^{(i)} - y^{(i)})^2 =  \frac{1}{n} (X \theta - Y)^T(X \theta - Y).$$
+$$J(\theta) = \frac{1}{n} \sum_{i=1}^n (\theta^T x^{(i)} - y^{(i)})^2 =  \frac{1}{n} (X \theta - Y)^T(X \theta - Y),$$
 
 and using facts about matrix/vector calculus, we get 
 
@@ -259,7 +260,7 @@ $$
 See @sec-matrix-calculus if you need some help finding this gradient.
 :::
 
-Setting this equal to zero and solving for $\theta$ yields the final closed-form solution:
+Setting this equal to zero and solving for $\theta$ (assuming $X^TX$ is invertible) yields the final closed-form solution:
 
 $$
 \theta^* = \left(X^T X\right)^{-1} X^T Y
@@ -302,7 +303,7 @@ $$
 
 where the "aug" denotes that $\theta, x$ have been augmented.
 
-Then we can now write the linear hypothesis **as if** there is no offset,
+We can now write the linear hypothesis **as if** there is no offset,
 
 $$
 y = h(x_{\text{aug}}; \theta_{\text{aug}}) = \theta_{\text{aug}}^T x_{\text{aug}} \;\;
@@ -325,11 +326,11 @@ Stop and prove to yourself that adding that extra feature with value 1 to every 
 
 ## Centering
 
-In fact, augmenting a “fake” feature of 1, as described above, is also useful for an important idea: namely, why utilizing the so-called **centering** eliminates the need for fitting an intercept, and thereby offers an alternative way to avoid dealing with $\theta_0$ directly.
+The “fake” feature of 1 described above also helps explain an important idea: **centering** eliminates the need for fitting an intercept explicitly, and thereby offers an alternative way to avoid dealing with $\theta_0$ directly.
 
 By **centering**, we mean subtracting the average (mean) of each feature from all data points, and we apply the same operation to the labels. For an example of a dataset before and after centering, see [here](https://slides.com/shensquared/introml-sp25-lec2#/4/5)
 
-The idea is that, with centered dataset, even if we were to search for an offset term $\theta_0$, it would naturally fall out to be 0. Intuitively, this makes sense -- if a dataset is centered around the origin, it seems natural that the best fitting plane would go through the origin.
+The idea is that, with a centered dataset, even if we were to search for an offset term $\theta_0$, it would naturally fall out to be 0. Intuitively, this makes sense -- if a dataset is centered around the origin, it seems natural that the best fitting plane would go through the origin.
 
 Let's see how this works out mathematically. First, for a *centered* dataset, two claims immediately follow  (recall that $\mathbb{1}$ is an $n$-by-1 vector of all ones):
 
@@ -361,7 +362,7 @@ The objective function of @eq-ml_objective_loss balances (training-data) memoriz
 
 If all we cared about was finding a hypothesis with small loss on the training data, we would have no need for regularization, and could simply omit the second term in the objective. But remember that our ultimate goal is to *perform well on input values that we haven't trained on!* It may seem that this is an impossible task, but humans and machine-learning methods do this successfully all the time. What allows *generalization* to new input values is a belief that there is an underlying regularity that governs both the training and testing data. One way to describe an assumption about such a regularity is by choosing a limited class of possible hypotheses. Another way to do this is to provide smoother guidance, saying that, within a hypothesis class, we prefer some hypotheses to others. The regularizer articulates this preference and the constant $\lambda$ says how much we are willing to trade off loss on the training data versus preference over hypotheses.
 
-For example, consider what happens when $d=2,$ and $x_2$ is highly correlated with $x_1$, meaning that the data look like a line, as shown in the left panel of the figure below. Thus, there are many hyperplanes that can achieve more or less the same training MSE. Such correlations happen often in real-life data, because of underlying common causes; for example, across a population, the height of people may depend on both age and amount of food intake in the same way. This is especially the case when there are many feature dimensions used in the regression. Mathematically, this leads to ${X}^T{X}$ close to singularity, such that $({X}^T{X})^{-1}$ is undefined or has huge values, resulting in unstable models (see the middle panel of figure and note the range of the $y$ values---the slope is huge!):
+For example, consider what happens when $d=2,$ and $x_2$ is highly correlated with $x_1$, meaning that the data look like a line, as shown in the left panel of the figure below. Thus, there are many hyperplanes that can achieve more or less the same training MSE. Such correlations happen often in real-life data, because of underlying common causes; for example, across a population, age and amount of food intake may themselves be highly correlated. This is especially the case when there are many feature dimensions used in the regression. Mathematically, this leads to ${X}^T{X}$ being close to singular, such that $({X}^T{X})^{-1}$ is undefined or has huge values, resulting in unstable models (see the middle panel of figure and note the range of the $y$ values---the slope is huge!):
 
 ![](figures/regression_ex2_plane1.png){width="100%"}
 
@@ -393,7 +394,7 @@ Note that, when data isn't centered, we don't penalize $\theta_0$; intuitively, 
 
 There is an analytical expression for the $\theta, \theta_0$ values that minimize $J_\text{ridge}$, even when the data isn't centered, but it's more complicated to derive than the solution for OLS, even though the process is conceptually similar: taking the gradient, setting it to zero, and solving for the parameters.
 
-The good news is, when the dataset is *centered*, we again have very clean set up and derivation. In particular, the objective can be written as:
+The good news is, when the dataset is *centered*, we again have a very clean setup and derivation. In particular, the objective can be written as:
 
 $$
 J_{\text{ridge}}(\theta) = \frac{1}{n}\sum_{i = 1}^n\left(\theta^Tx^{(i)}  - y^{(i)}\right)^2 + \lambda\|\theta\|^2
@@ -428,7 +429,7 @@ $$\begin{aligned}
 :::
 
 
-One other great news is that in @eq-regularized-solution, the matrix we are trying to invert can always be inverted! Why is the term $\left({X}^T{X}+ n\lambda I\right)$ invertible? Explaining this requires some linear algebra. The matrix ${X}^T{X}$ is positive semidefinite, which implies that its eigenvalues $\{\gamma_i\}_i$ are greater than or equal to 0. The matrix ${X}^T{X}+n\lambda I$ has eigenvalues $\{\gamma_i+n\lambda\}_i$ which are guaranteed to be strictly positive since $\lambda>0$. Recalling that the determinant of a matrix is simply the product of its eigenvalues, we get that $\det({X}^T{X}+ n\lambda I)>0$ and conclude that ${X}^T{X}+ n\lambda I$ is invertible.
+One other great news is that in @eq-ridge_regression_solution, the matrix we are trying to invert can always be inverted, as long as $\lambda > 0$! Why is the term $\left({X}^T{X}+ n\lambda I\right)$ invertible? Explaining this requires some linear algebra. The matrix ${X}^T{X}$ is positive semidefinite, which implies that its eigenvalues $\{\gamma_i\}_i$ are greater than or equal to 0. The matrix ${X}^T{X}+n\lambda I$ has eigenvalues $\{\gamma_i+n\lambda\}_i$ which are guaranteed to be strictly positive since $\lambda>0$. Recalling that the determinant of a matrix is simply the product of its eigenvalues, we get that $\det({X}^T{X}+ n\lambda I)>0$ and conclude that ${X}^T{X}+ n\lambda I$ is invertible.
 
 ## Evaluating learning algorithms {#sec-reg_learn_alg}
 
@@ -438,7 +439,7 @@ We have seen how linear regression is a well-formed optimization problem, which 
 
 ### Evaluating hypotheses
 
-The performance of a given hypothesis $h$ may be evaluated by measuring *test error* on data that was not used to train it. Given a training set ${\cal D}_n,$ a regression hypothesis $h$, and if we choose squared loss, we can define the OLS *training error* of $h$ to be the mean square error between its predictions and the expected outputs: 
+The performance of a given hypothesis $h$ may be evaluated by measuring *test error* on data that was not used to train it. Given a training set $\mathcal{D}_\text{train}$ and a regression hypothesis $h$, if we choose squared loss, we can define the *training error* of $h$ to be the mean square error between its predictions and the target outputs:
 $$
 \begin{aligned}
   \mathcal{E}_{\text{train}}(h) = \frac{1}{n}\sum_{i = 1}^{n} \left[ h(x^{(i)}) - y^{(i)} \right]^2
@@ -466,7 +467,7 @@ When we increase $\lambda$, we tend to increase structural error but decrease es
 
 *Note that this section is relevant to learning algorithms generally---we are just introducing the topic here since we now have an algorithm that can be evaluated!*
 
-A *learning algorithm* is a procedure that takes a data set ${\cal D}_n$ as input and returns an hypothesis $h$ from a hypothesis class ${\cal H}$; it looks like 
+A *learning algorithm* is a procedure that takes a data set $\mathcal{D}_\text{train}$ as input and returns an hypothesis $h$ from a hypothesis class ${\cal H}$; it looks like 
 $$  \mathcal{D}_{\text{train}} \longrightarrow \boxed{\text{learning alg (${\cal H}$)}} \longrightarrow h$$
  Keep in mind that $h$ has parameters. The learning algorithm itself may have its own parameters, and such parameters are often called *hyperparameters*. The analytical solutions presented above for linear regression, e.g., @eq-ridge_regression_solution, may be thought of as learning algorithms, where $\lambda$ is a hyperparameter that governs how the learning algorithm works and can strongly affect its performance.
 
@@ -500,6 +501,7 @@ One concern is that we might need a lot of data to do this, and in many applicat
 #| html-no-end: false
 #| pdf-placement: "htb!"
 #| pdf-line-number: true
+#| label: Cross-Validate
 
 \begin{algorithm}
     \caption{Cross-Validate}


### PR DESCRIPTION
Part of a chapter-by-chapter polish pass.

- Fix wrong cross-reference: the "matrix we are trying to invert" sentence pointed at the gradient equation (@eq-regularized-solution), now points at the ridge closed-form solution, with the "as long as lambda > 0" condition made explicit
- Unify Random-Regression pseudocode index notation to theta^(i) (was three different styles in four lines)
- Add `#| label:` to both pseudocode blocks so they number as Algorithm 2.1 and 2.2 (both previously rendered as 2.1). Note: `alg-` prefixed labels crash Quarto's crossref filter because of the custom `alg` crossref type in _quarto.yml; plain names work
- Add X^T X invertibility caveat to the OLS closed form
- varphi -> phi in the feature-transform margin note (only file using varphi)
- Fix the correlated-features example (age and food intake correlated with each other, not both driving height "in the same way")
- Assorted grammar and punctuation

Verified: full `quarto render` passes; regression.html now shows distinct algorithm numbers.