### PR TITLE
Polish gradient descent and classification chapters

### DIFF
--- a/classification.qmd
+++ b/classification.qmd
@@ -2,7 +2,7 @@
 
 ## Problem formulation
 
-Classification is a machine learning problem seeking to map from inputs $\mathbb{R}^d$ to outputs in an unordered set. 
+Classification is a machine learning problem seeking to map from inputs in $\mathbb{R}^d$ to outputs in an unordered set. 
 
 :::{.column-margin}
 This is in contrast to a continuous real-valued output, as we saw for linear regression.
@@ -12,7 +12,7 @@ Examples of classification output sets could be $\{\text{apples}, \text{oranges}
 
 Like regression, classification is a *supervised learning* problem, in which we are given a training data set of the form 
 
-$${\cal D}_{\text{train}} = \left\{\left(x^{(1)}, y^{(1)}\right), \dots, \left(x^{(n)},
+$$\mathcal{D}_{\text{train}} = \left\{\left(x^{(1)}, y^{(1)}\right), \dots, \left(x^{(n)},
   y^{(n)}\right)\right\} \;\;.
 $$ 
 
@@ -20,7 +20,7 @@ We will assume that each $x^{(i)}$ is a $d \times 1$ *column vector*. The intend
 
 What makes a classifier useful? As in regression, we want it to work well on new data, making good predictions on examples it hasn't seen. But we don't know exactly what data this classifier might be tested on when we use it in the real world. So, we have to *assume* a connection between the training data and testing data; typically, they are drawn independently from the same probability distribution.
 
-In classification, we will often use 0-1 loss for evaluation (as discussed in @sec-evaluation). For that choice, we can write the training error and the testing error. In particular, given a training set ${\cal D}_{\text{train}}$ and a classifier $h$, we define the *training error* of $h$ to be 
+In classification, we will often use 0-1 loss for evaluation (as discussed in @sec-evaluation). For that choice, we can write the training error and the testing error. In particular, given a training set $\mathcal{D}_{\text{train}}$ and a classifier $h$, we define the *training error* of $h$ to be 
 
 $$
 \begin{aligned}
@@ -48,7 +48,7 @@ We start with the hypothesis class of *linear classifiers*. They are (relatively
 
 ### Linear classifiers: definition
 
-A linear classifier in $d$ dimensions is defined by a vector of parameters $\theta \in \mathbb{R}^d$ and scalar $\theta_0 \in \mathbb{R}$. So, the hypothesis class ${\cal H}$ of linear classifiers in $d$ dimensions is parameterized by the *set* of all vectors in $\mathbb{R}^{d+1}$. We'll assume that $\theta$ is a $d \times 1$ column vector.
+A linear classifier in $d$ dimensions is defined by a vector of parameters $\theta \in \mathbb{R}^d$ and scalar $\theta_0 \in \mathbb{R}$. So, the hypothesis class $\mathcal{H}$ of linear classifiers in $d$ dimensions is parameterized by the *set* of all vectors in $\mathbb{R}^{d+1}$. We'll assume that $\theta$ is a $d \times 1$ column vector.
 
 Given particular values for $\theta$ and $\theta_0$, the classifier is defined by 
 $$\begin{aligned}
@@ -172,7 +172,7 @@ What makes this a difficult optimization problem is its lack of "smoothness":
 
 -   All predictions are categorical: the classifier can't express a degree of certainty about whether a particular input $x$ should have an associated value $y$.
 
-For these reasons, if we are considering a hypothesis $\theta,\theta_0$ that makes five incorrect predictions, it is difficult to see how we might change $\theta,\theta_0$ so that it will perform better, which makes it difficult to design an algorithm that searches in a sensible way through the space of hypotheses for a good one. For these reasons, we investigate another hypothesis class: *linear logistic classifiers*, providing their definition, then an approach for learning such classifiers using optimization.
+For these reasons, if we are considering a hypothesis $\theta,\theta_0$ that makes five incorrect predictions, it is difficult to see how we might change $\theta,\theta_0$ so that it will perform better, which makes it difficult to design an algorithm that searches in a sensible way through the space of hypotheses for a good one. So, we investigate another hypothesis class: *linear logistic classifiers*, providing their definition, then an approach for learning such classifiers using optimization.
 
 ### Linear logistic classifiers: definition
 
@@ -218,7 +218,7 @@ Convince yourself the output of $\sigma$ is always in the interval $(0, 1)$.  Wh
 
 ### Linear logistic classifier: examples
 
-What does an LLC look like? Let's consider the simple case where $d = 1$, so our input points simply lie along the $x$ axis. Classifiers in this case have dimension $0$, meaning that they are points. The plot below shows LLCs for three different parameter settings: $\sigma(10x + 1)$, $\sigma(-2x + 1)$, and $\sigma(2x - 3).$
+What does an LLC look like? Let's consider the simple case where $d = 1$, so our input points simply lie along the $x$ axis. Separators in this case have dimension $0$, meaning that they are points. The plot below shows LLCs for three different parameter settings: $\sigma(10x + 1)$, $\sigma(-2x + 1)$, and $\sigma(2x - 3).$
 
 :::{.imagify}
 \begin{center}
@@ -270,7 +270,7 @@ When $d = 2$, then our inputs $x$ lie in a two-dimensional space with axes $x_1$
 
 :::{.study-question-callout}
 Convince yourself that the set of points for which
-  $\sigma(\theta^T x + \theta_0) = 0.5$, that is, the ``boundary''
+  $\sigma(\theta^T x + \theta_0) = 0.5$, that is, the "boundary"
   between positive and negative predictions with prediction threshold
   $0.5$, is a line in $(x_1, x_2)$ space. What particular line is it
   for the case in the figure above?
@@ -286,7 +286,7 @@ For learning LLCs, we'd have a class of hypotheses whose outputs are in $(0, 1)$
 
 :::{.study-question-callout}
 If $h(x)$ is the probability that $x$ belongs to class $+1$,
-  what is the probability that $x$ belongs to the class $-1$, assuming there are only these two classes?
+  what is the probability that $x$ belongs to the class $0$, assuming there are only these two classes?
 :::
 
 Intuitively, we would like to have *low loss if we assign a high probability to the correct class.* We'll define a loss function, called *negative log-likelihood* (NLL), that does just this. In addition, it has the cool property that it extends nicely to the case where we would like to classify our inputs into more than two classes.
@@ -345,7 +345,7 @@ The choice of log base doesn't make any real difference here. When we ask you fo
 
 **What is the objective function for linear logistic classification?** We can finally put all these pieces together and develop an objective function for optimizing regularized negative log-likelihood for a linear logistic classifier. In fact, this process is usually called "logistic regression," so we'll call our objective $J_\text{lr}$, and define it as 
 $$
-J_\text{lr}(\theta, \theta_0; {\cal D}) =
+J_\text{lr}(\theta, \theta_0; \mathcal{D}) =
   \left(\frac{1}{n} \sum_{i=1}^n
   \mathcal{L}_\text{nll}(\sigma(\theta^T x^{(i)} + \theta_0), y^{(i)})\right) +
   \lambda \left\lVert\theta\right\rVert^2\;\;.
@@ -365,7 +365,7 @@ Suppose we wish to obtain a linear logistic classifier for this one-dimensional 
 
 ![](figures/linear_logistic_classifier_and_regularization_data.png){width="45%" fig-align="center"}
 
-Clearly, this can be fit very nicely by a hypothesis $h(x)=\sigma(\theta x)$, but what is the best value for $\theta$? Evidently, when there is no regularization ($\lambda=0$), the objective function $J_{lr}(\theta)$ will approach zero for large values of $\theta$, as shown in the plot on the left, below. However, would the best hypothesis really have an infinite (or very large) value for $\theta$? Such a hypothesis would suggest that the data indicate strong certainty that a sharp transition between $y=0$ and $y=1$ occurs exactly at $x=0$, despite the actual data having a wide gap around $x=0$.
+Clearly, this can be fit very nicely by a hypothesis $h(x)=\sigma(\theta x)$, but what is the best value for $\theta$? Evidently, when there is no regularization ($\lambda=0$), the objective function $J_\text{lr}(\theta)$ will approach zero for large values of $\theta$, as shown in the plot on the left, below. However, would the best hypothesis really have an infinite (or very large) value for $\theta$? Such a hypothesis would suggest that the data indicate strong certainty that a sharp transition between $y=0$ and $y=1$ occurs exactly at $x=0$, despite the actual data having a wide gap around $x=0$.
 
 :::{layout-ncol="2"}
 
@@ -374,15 +374,15 @@ Clearly, this can be fit very nicely by a hypothesis $h(x)=\sigma(\theta x)$, bu
 ![](figures/linear_logistic_classifier_and_regularization_objective_withreg.png){width="45%"}
 :::
 
-In absence of other beliefs about the solution, we might prefer that our linear logistic classifier not be overly certain about its predictions, and so we might prefer a smaller $\theta$ over a large $\theta.$ By not being overconfident, we might expect a somewhat smaller $\theta$ to perform better on future examples drawn from this same distribution. This preference can be realized using a nonzero value of the regularization trade-off parameter, as illustrated in the plot on the right, above, with $\lambda=0.2$.
+In the absence of other beliefs about the solution, we might prefer that our linear logistic classifier not be overly certain about its predictions, and so we might prefer a smaller $\theta$ over a large $\theta.$ By not being overconfident, we might expect a somewhat smaller $\theta$ to perform better on future examples drawn from this same distribution. This preference can be realized using a nonzero value of the regularization trade-off parameter, as illustrated in the plot on the right, above, with $\lambda=0.2$.
 
 Another nice way of thinking about regularization is that we would like to prevent our hypothesis from being too dependent on the particular training data that we were given: we would like for it to be the case that if the training data were changed slightly, the hypothesis would not change by much.
 
 ## Gradient descent for logistic regression {#sec-gd_lrr}
 
-Now that we have a hypothesis class (LLC) and a loss function (NLL), we need to take some data and find parameters! Sadly, there is no lovely analytical solution like the one we obtained for regression, in @sec-ridge_regression. Good thing we studied gradient descent! We can perform gradient descent on the $J_{lr}$ objective, as we'll see next. We can also apply stochastic gradient descent to this problem.
+Now that we have a hypothesis class (LLC) and a loss function (NLL), we need to take some data and find parameters! Sadly, there is no lovely analytical solution like the one we obtained for regression, in @sec-ridge_regression. Good thing we studied gradient descent! We can perform gradient descent on the $J_\text{lr}$ objective, as we'll see next. We can also apply stochastic gradient descent to this problem.
 
-Luckily, $J_{lr}$ has enough nice properties that gradient descent and stochastic gradient descent should generally "work". We'll soon see some more challenging optimization problems though -- in the context of neural networks, in @sec-make_nn_work.
+Luckily, $J_\text{lr}$ has enough nice properties that gradient descent and stochastic gradient descent should generally "work". We'll soon see some more challenging optimization problems though -- in the context of neural networks, in @sec-make_nn_work.
 
 First we need derivatives with respect to both $\theta_0$ (the scalar component) and $\theta$ (the vector component) of $\Theta$. Explicitly, they are: 
 $$
@@ -399,9 +399,6 @@ $$
 $$ 
 
 Note that $\nabla_\theta J_\text{lr}$ will be of shape $d \times 1$ and $\frac{\partial J_\text{lr}}{\partial \theta_0}$ will be a scalar since we have separated $\theta_0$ from $\theta$ here.
-
-Putting everything together, our gradient descent algorithm for logistic regression becomes:
-
 
 ::: {.study-question-callout}
 Convince yourself that the dimensions of all these quantities are correct, under the assumption that $\theta$ is $d \times 1$.
@@ -422,6 +419,7 @@ $\left(\frac{\partial \mathcal{L}_\text{nll}\bigl(\sigma(\theta^T x + \theta_0),
 Use these last two results to verify our derivation above.
 :::
 
+Putting everything together, our gradient descent algorithm for logistic regression becomes:
 
 ```pseudocode
 #| html-indent-size: "1.2em"
@@ -432,18 +430,19 @@ Use these last two results to verify our derivation above.
 #| pdf-placement: "htb!"
 #| pdf-line-number: true
 
-\begin{algorithm}[H]
-\caption{LR-Gradient-Descent($\theta_{\text{init}}, \theta_{0\,\text{init}}, \eta, \epsilon$)}
-\begin{algorithmic}[1]
-\State $\theta^{(0)} \gets \theta_{\text{init}}$
-\State $\theta_0^{(0)} \gets \theta_{0\,\text{init}}$
-\State $t \gets 0$
-\Repeat
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{LR-Gradient-Descent}{$\theta_{\text{init}}, \theta_{0\,\text{init}}, \eta, \epsilon$}
+  \State $\theta^{(0)} \gets \theta_{\text{init}}$
+  \State $\theta_0^{(0)} \gets \theta_{0\,\text{init}}$
+  \State $t \gets 0$
+  \Repeat
     \State $t \gets t + 1$
-    \State $\theta^{(t)} \gets \theta^{(t-1)} - \eta \Biggl( \frac{1}{n}\sum_{i=1}^n \Bigl( \sigma\Bigl({\theta}^{(t-1)T} x^{(i)} + \theta_0^{(t-1)}\Bigr) - y^{(i)} \Bigr) x^{(i)} + 2\lambda\,\theta^{(t-1)} \Biggr)$
-    \State $\theta_0^{(t)} \gets \theta_0^{(t-1)} - \eta \Biggl( \frac{1}{n}\sum_{i=1}^n \Bigl( \sigma\Bigl({\theta}^{(t-1)T} x^{(i)} + \theta_0^{(t-1)}\Bigr) - y^{(i)} \Bigr) \Biggr)$
-\Until{$\Bigl| J_{\text{lr}}(\theta^{(t)},\theta_0^{(t)}) - J_{\text{lr}}(\theta^{(t-1)},\theta_0^{(t-1)}) \Bigr| < \epsilon$}
-\Return $\theta^{(t)}, \theta_0^{(t)}$
+    \State $\theta^{(t)} \gets \theta^{(t-1)} - \eta \Biggl( \frac{1}{n}\sum_{i=1}^n \Bigl( \sigma\Bigl(\left(\theta^{(t-1)}\right)^T x^{(i)} + \theta_0^{(t-1)}\Bigr) - y^{(i)} \Bigr) x^{(i)} + 2\lambda\,\theta^{(t-1)} \Biggr)$
+    \State $\theta_0^{(t)} \gets \theta_0^{(t-1)} - \eta \Biggl( \frac{1}{n}\sum_{i=1}^n \Bigl( \sigma\Bigl(\left(\theta^{(t-1)}\right)^T x^{(i)} + \theta_0^{(t-1)}\Bigr) - y^{(i)} \Bigr) \Biggr)$
+  \Until{$\Bigl| J_{\text{lr}}(\theta^{(t)},\theta_0^{(t)}) - J_{\text{lr}}(\theta^{(t-1)},\theta_0^{(t-1)}) \Bigr| < \epsilon$}
+  \Return{$\theta^{(t)}, \theta_0^{(t)}$}
+\EndProcedure
 \end{algorithmic}
 \end{algorithm}
 ```
@@ -500,7 +499,7 @@ So far, we have focused on the *binary* classification case, with only two possi
 
 -   Directly train a multi-class classifier using a hypothesis class that is a generalization of logistic regression, using a *one-hot* output encoding and NLL loss.
 
-The method based on NLL is in wider use, especially in the context of neural networks, and is explored here. In the following, we will assume that we have a data set ${\cal D}$ in which the inputs $x^{(i)} \in R^d$ but the outputs $y^{(i)}$ are drawn from a set of $K$ classes $\{c_1, \ldots, c_K\}$. Next, we extend the idea of NLL directly to multi-class classification with $K$ classes, where the training label is represented with what is called a *one-hot* vector $y=\begin{bmatrix} y_1, \ldots, y_K \end{bmatrix}^T$, where $y_k=1$ if the example is of class $k$ and $y_k = 0$ otherwise. Now, we have a problem of mapping an input $x^{(i)}$ that is in $\mathbb{R}^d$ into a $K$-dimensional output. Furthermore, we would like this output to be interpretable as a discrete probability distribution over the possible classes, which means the elements of the output vector have to be *non-negative* (greater than or equal to 0) and sum to 1.
+The method based on NLL is in wider use, especially in the context of neural networks, and is explored here. In the following, we will assume that we have a data set $\mathcal{D}$ in which the inputs $x^{(i)} \in \mathbb{R}^d$ but the outputs $y^{(i)}$ are drawn from a set of $K$ classes $\{c_1, \ldots, c_K\}$. Next, we extend the idea of NLL directly to multi-class classification with $K$ classes, where the training label is represented with what is called a *one-hot* vector $y=\begin{bmatrix} y_1, \ldots, y_K \end{bmatrix}^T$, where $y_k=1$ if the example is of class $k$ and $y_k = 0$ otherwise. Now, we have a problem of mapping an input $x^{(i)}$ that is in $\mathbb{R}^d$ into a $K$-dimensional output. Furthermore, we would like this output to be interpretable as a discrete probability distribution over the possible classes, which means the elements of the output vector have to be *non-negative* (greater than or equal to 0) and sum to 1.
 
 We will do this in two steps. First, we will map our input $x^{(i)}$ into a vector value $z^{(i)} \in \mathbb{R}^K$ by letting $\theta$ be a whole $d \times K$ *matrix* of parameters, and $\theta_0$ be a $K \times 1$ vector, so that 
 
@@ -521,9 +520,9 @@ g = \operatorname{softmax}(z) =
       \exp(z_1) / \sum_{i} \exp(z_i) \\
       \vdots                         \\
       \exp(z_K) / \sum_{i} \exp(z_i)
-    \end{bmatrix}\;\;.
-$$ 
-which can be interpreted as a probability distribution over $K$ items. To make the final prediction of the class label, we can then look at $g,$ find the most probable class over these $K$ entries in $g,$ (i.e. find the largest entry in $g,$) and return the corresponding index as the "one-hot" element of $1$ in our prediction.
+    \end{bmatrix}\;\;,
+$$
+which can be interpreted as a probability distribution over $K$ items. To make the final prediction of the class label, we can then find the largest of the $K$ entries in $g$ and return the corresponding index as our predicted class.
 
 :::{.study-question-callout}
 Convince yourself that the vector of $g$ values will be non-negative and sum to 1.
@@ -539,13 +538,13 @@ How many elements that are not equal to 1 will there be in this product?
 
 The negative log of the probability that we are making a correct guess is, then, for *one-hot* vector $y$ and *probability distribution* vector $g$, 
 $$
-\mathcal{L}_\text{nllm}(\text{g},\text{y}) =
-  - \sum_{k=1}^K \text{y}_k \cdot \log(\text{g}_k) \;\;.
+\mathcal{L}_\text{nllm}(g, y) =
+  - \sum_{k=1}^K y_k \cdot \log(g_k) \;\;.
 $$ 
 We'll call this nllm for *negative log likelihood multiclass.* It is also worth noting that the NLLM loss function is also convex; however, we will omit the proof.
 
 :::{.study-question-callout}
-Be sure you see that is $\mathcal{L}_\text{nllm}$ is minimized when the guess assigns high probability to the true class.
+Be sure you see that $\mathcal{L}_\text{nllm}$ is minimized when the guess assigns high probability to the true class.
 :::
 
 :::{.study-question-callout}
@@ -556,4 +555,4 @@ Show that $\mathcal{L}_\text{nllm}$ for $K = 2$ is the same as $\mathcal{L}_\tex
 
 In order to formulate classification with a smooth objective function that we can optimize robustly using gradient descent, we changed the output from discrete classes to probability values and the loss function from 0-1 loss to NLL. However, when time comes to actually make a prediction we usually have to make a hard choice: buy stock in Acme or not? And, we get rewarded if we guessed right, independent of how sure or not we were when we made the guess.
 
-The performance of a classifier is often characterized by its *accuracy*, which is the percentage of a data set that it predicts correctly in the case of 0-1 loss. We can see that accuracy of hypothesis $h$ on data ${\cal D}$ is the fraction of the data set that does not incur any loss: $$A(h; {\cal D}) = 1 - \frac{1}{n}\sum_{i=1}^n\mathcal{L}_{01}(g^{(i)}, y^{(i)})\;\;,$$ where $g^{(i)}$ is the final guess for one class or the other that we make from $h(x^{(i)})$, e.g., after thresholding. It's noteworthy here that we use a different loss function for optimization than for evaluation. This is a compromise we make for computational ease and efficiency.
+The performance of a classifier is often characterized by its *accuracy*, which is the percentage of a data set that it predicts correctly in the case of 0-1 loss. We can see that accuracy of hypothesis $h$ on data $\mathcal{D}$ is the fraction of the data set that does not incur any loss: $$A(h; \mathcal{D}) = 1 - \frac{1}{n}\sum_{i=1}^n\mathcal{L}_{01}(g^{(i)}, y^{(i)})\;\;,$$ where $g^{(i)}$ is the final guess for one class or the other that we make from $h(x^{(i)})$, e.g., after thresholding. It's noteworthy here that we use a different loss function for optimization than for evaluation. This is a compromise we make for computational ease and efficiency.

--- a/gradient_descent.qmd
+++ b/gradient_descent.qmd
@@ -1,6 +1,6 @@
 # Gradient Descent {#sec-gradient}
 
-In the previous chapter, we showed how to describe an interesting objective function for machine learning, but we need a way to find the optimal $\Theta^* = {\rm arg}\min_{\Theta} J(\Theta)$, particularly when the objective function is not amenable to analytical optimization. For example, this can happen when $J(\Theta)$ involves a more complex loss function or more general forms of regularization. It can also be the case when there are simply too many parameters to learn for it to be computationally feasible.
+In the previous chapter, we showed how to describe an interesting objective function for machine learning, but we need a way to find the optimal $\Theta^* = \arg\min_{\Theta} J(\Theta)$, particularly when the objective function is not amenable to analytical optimization. For example, this can happen when $J(\Theta)$ involves a more complex loss function or more general forms of regularization. It can also be the case when there are simply too many parameters to learn for it to be computationally feasible.
 
 There is an enormous and fascinating literature on the mathematical and algorithmic foundations of optimization, but for this class we will consider one of the simplest methods, called *gradient descent.*
 
@@ -10,11 +10,11 @@ You might want to consider studying optimization someday! It's one of the fundam
 
 Intuitively, in one or two dimensions, we can easily think of $J(\Theta)$ as defining a surface over $\Theta$; that same idea extends to higher dimensions. Now, our objective is to find the $\Theta$ value at the lowest point on that surface. One way to think about gradient descent is to start at some arbitrary point on the surface, see which direction the "hill" slopes downward most steeply, take a small step in that direction, determine the next steepest descent direction, take another small step, and so on.
 
-Below, we explicitly give gradient descent algorithms for one-  and multidimensional objective functions (@sec-gd_onedim and @sec-gd). We then illustrate the application of gradient descent to a loss function which is not merely mean squared loss (@sec-gd_ridge). And we present an important method known as *stochastic gradient descent* (@sec-sgd), which is especially useful when datasets are too large for descent in a single batch, and has some important behaviors of its own.
+Below, we explicitly give gradient descent algorithms for one-  and multidimensional objective functions (@sec-gd_onedim and @sec-gd). We then illustrate the application of gradient descent to a loss function which is not merely mean squared loss (@sec-gd_ridge). And we present an important method known as *stochastic gradient descent* (@sec-sgd), which is especially useful when datasets are too large for descent in a single batch, and has some important behaviors of its own. Finally, we present *mini-batch gradient descent* (@sec-minibatch), a practical middle ground between the two.
 
 ## Gradient descent in one dimension {#sec-gd_onedim}
 
-We start by considering gradient descent in one dimension. Assume $\Theta \in \mathbb{R}$, and that we know both $J(\Theta)$ and its first derivative with respect to $\Theta$, $J'(\Theta)$. Here is pseudocode for gradient descent on an arbitrary function $f$. Along with $f$ and its gradient $\nabla_{\Theta}f$ (which, in the case of a scalar $\Theta$, is the same as its derivative $f'$), we have to specify some hyper-parameters. These hyper-parameters include the initial value for parameter $\Theta$, a *learning rate* hyper-parameter $\eta$, and an *accuracy* hyper-parameter $\epsilon$.
+We start by considering gradient descent in one dimension. Assume $\Theta \in \mathbb{R}$, and that we know both $J(\Theta)$ and its first derivative with respect to $\Theta$, $J'(\Theta)$. Here is pseudocode for gradient descent on an arbitrary function $f$. Along with $f$ and its gradient $\nabla_{\Theta}f$ (which, in the case of a scalar $\Theta$, is the same as its derivative $f'$), we have to specify some hyperparameters. These hyperparameters include the initial value for parameter $\Theta$, a *learning rate* hyperparameter $\eta$, and an *accuracy* hyperparameter $\epsilon$.
 
 For simplicity, $\eta$ may be taken as a constant, as is the case in the pseudocode below; and we'll see adaptive (non-constant) learning rates soon. What's important to notice, though, is that even when $\eta$ is constant, the actual magnitude of the change to $\Theta$ may not be constant, as that change depends on the magnitude of the gradient itself too.
 
@@ -29,8 +29,8 @@ For simplicity, $\eta$ may be taken as a constant, as is the case in the pseudoc
 
 \begin{algorithm}
 \begin{algorithmic}
-\Procedure{1D-Gradient-Descent}{$\Theta_{init}, \eta, f, f', \epsilon$}
-  \State $\Theta^{(0)} \gets \Theta_{init}$
+\Procedure{1D-Gradient-Descent}{$\Theta_{\text{init}}, \eta, f, f', \epsilon$}
+  \State $\Theta^{(0)} \gets \Theta_{\text{init}}$
   \State $t \gets 0$
   \Repeat
     \State $t \gets t+1$
@@ -56,7 +56,7 @@ Consider all of the potential stopping criteria for `1D-Gradient-Descent`, both 
 :::
 
 :::{#thm-gd}
-*Choose any small distance $\tilde{\epsilon} > 0$. If we assume that $f$ has a minimum, is sufficiently "smooth" and convex, and if the learning rate $\eta$ is sufficiently small, gradient descent will reach a point within $\tilde{\epsilon}$ of a global optimum point $\Theta$.*
+*Choose any small distance $\tilde{\epsilon} > 0$. If we assume that $f$ has a minimum, is sufficiently "smooth" and convex, and if the learning rate $\eta$ is sufficiently small, gradient descent will reach a point within $\tilde{\epsilon}$ of a global minimum point $\Theta^*$.*
 :::
 
 However, we must be careful when choosing the learning rate to prevent slow convergence, non-converging oscillation around the minimum, or divergence.
@@ -86,7 +86,7 @@ The following plot illustrates a convex function $f(x) = (x - 2)^2$, starting gr
 :::
 
 
-If $f$ is non-convex, where gradient descent converges depends on $x_{\it init}$. First, let's establish some definitions. Let $f$ be a real-valued function defined over some domain $D$. A point $x_0 \in D$ is called a *global minimum point* of $f$ if $f(x_0) \leq f(x)$ for all other $x \in D$. A point $x_0 \in D$ is instead called a *local minimum point* of a function $f$ if there exists some constant $\epsilon > 0$ such that for all $x$ within the interval defined by $d(x,x_0) < \epsilon,$ $f(x_0) \leq f(x)$, where $d$ is some distance metric, e.g., $d(x,x_0) = || x - x_0 ||.$ A global minimum point is also a local minimum point, but a local minimum point does not have to be a global minimum point.
+If $f$ is non-convex, where gradient descent converges depends on $x_{\it init}$. First, let's establish some definitions. Let $f$ be a real-valued function defined over some domain $D$. A point $x_0 \in D$ is called a *global minimum point* of $f$ if $f(x_0) \leq f(x)$ for all other $x \in D$. A point $x_0 \in D$ is instead called a *local minimum point* of a function $f$ if there exists some constant $\delta > 0$ such that for all $x$ in the neighborhood defined by $d(x,x_0) < \delta$, $f(x_0) \leq f(x)$, where $d$ is some distance metric, e.g., $d(x,x_0) = \lVert x - x_0 \rVert.$ A global minimum point is also a local minimum point, but a local minimum point does not have to be a global minimum point.
 
 
 ::: {.study-question-callout}
@@ -97,7 +97,7 @@ What happens in this example with very small $\eta$?  With very big $\eta$?
 
 If $f$ is non-convex (and sufficiently smooth), one expects that gradient descent (run long enough with small enough learning rate) will get very close to a point at which the gradient is zero, though we cannot guarantee that it will converge to a global minimum point.
 
-There are two notable exceptions to this common sense expectation: First, gradient descent can stagnate while approaching a point $x$ that is not a local minimum or maximum, but satisfies $f'(x)=0$. For example, for $f(x)=x^3$, starting gradient descent from the initial guess $x_{\it init}=1$, while using learning rate $\eta<1/3$ will lead to $x^{(k)}$ converging to zero as $k\to\infty$. Second, there are functions (even convex ones) with no minimum points, such as $f(x)=\exp(-x)$, for which gradient descent with a positive learning rate converges to $+\infty$.
+There are two notable exceptions to this common sense expectation: First, gradient descent can stagnate while approaching a point $x$ that is not a local minimum or maximum, but satisfies $f'(x)=0$. For example, for $f(x)=x^3$, starting gradient descent from the initial guess $x_{\it init}=1$, while using learning rate $\eta<1/3$ will lead to $x^{(t)}$ converging to zero as $t\to\infty$. Second, there are functions (even convex ones) with no minimum points, such as $f(x)=\exp(-x)$, for which the gradient descent iterates head off to $+\infty$; there is no minimum point to converge to.
 
 The plot below shows two different $x_{\it init}$, and how gradient descent started from each point heads toward two different local optimum points.
 
@@ -148,10 +148,10 @@ The extension to the case of multidimensional $\Theta$ is straightforward. Let's
   \end{bmatrix}
   $$
    
-The algorithm remains the same, except that the update step in line 5 becomes 
+The algorithm remains the same, except that the update step becomes
 $$
 \Theta^{(t)} = \Theta^{(t-1)} - \eta\nabla_\Theta f(\Theta^{(t-1)})
-$$ and any termination criteria that depend on the dimensionality of $\Theta$ would have to change. The easiest thing is to keep the test in line 6 as $\left|f(\Theta^{(t)}) - f(\Theta^{(t-1)}) \right| < \epsilon$, which is sensible no matter the dimensionality of $\Theta$.
+$$ and any termination criteria that depend on the dimensionality of $\Theta$ would have to change. The easiest thing is to keep the termination test as $\left|f(\Theta^{(t)}) - f(\Theta^{(t-1)}) \right| < \epsilon$, which is sensible no matter the dimensionality of $\Theta$.
 
 ::: {.study-question-callout}
 Which termination criteria from the 1D case were defined in a way that assumes $\Theta$ is one dimensional?
@@ -175,6 +175,9 @@ $$
   \,.
 $$
 
+:::{.column-margin}
+Beware double superscripts!  $\left[ \theta \right]^T$ is the transpose of the vector $\theta$.
+:::
 
 ### Ridge regression
 Now, let's add in the regularization term, to get the ridge-regression
@@ -209,20 +212,15 @@ Convince yourself that the dimensions of all these
 :::
 
 ::: {.study-question-callout}
-Compute $\nabla_\theta ||\theta||^2$ by finding the
-  vector of partial derivatives $(\partial ||\theta||^2 / \partial
-    \theta_1, \ldots, \partial ||\theta||^2 / \partial
-    \theta_d)$. What is the shape of $\nabla_\theta ||\theta||^2$?
+Compute $\nabla_\theta \lVert\theta\rVert^2$ by finding the
+  vector of partial derivatives $(\partial \lVert\theta\rVert^2 / \partial
+    \theta_1, \ldots, \partial \lVert\theta\rVert^2 / \partial
+    \theta_d)$. What is the shape of $\nabla_\theta \lVert\theta\rVert^2$?
 :::
 
 ::: {.study-question-callout}
-Compute $\nabla_\theta J_\text{ridge}(
-    \theta^T x + \theta_0, y)$ by finding the
-  vector of partial derivatives $(\partial J_\text{ridge}(
-    \theta^T x + \theta_0, y)/ \partial \theta_1, \ldots,
-    \partial J_\text{ridge}(
-    \theta^T x + \theta_0, y) / \partial
-    \theta_d)$.
+Compute $\nabla_\theta \left(\theta^T x + \theta_0 - y\right)^2$ by finding the
+  vector of partial derivatives $\left(\partial (\theta^T x + \theta_0 - y)^2 / \partial \theta_1, \ldots, \partial (\theta^T x + \theta_0 - y)^2 / \partial \theta_d\right)$.
 :::
 
 ::: {.study-question-callout}
@@ -242,9 +240,9 @@ Putting everything together, our gradient descent algorithm for ridge regression
 
 \begin{algorithm}
 \begin{algorithmic}
-\Procedure{RR-Gradient-Descent}{$\theta_{\it init}, \theta_{0 {\it init}},\eta,\epsilon$}
-  \State $\theta^{(0)} \gets \theta_{\it init}$
-  \State $\theta_0^{(0)} \gets \theta_{0 {\it init}}$
+\Procedure{RR-Gradient-Descent}{$\theta_{\text{init}}, \theta_{0\,\text{init}},\eta,\epsilon$}
+  \State $\theta^{(0)} \gets \theta_{\text{init}}$
+  \State $\theta_0^{(0)} \gets \theta_{0\,\text{init}}$
   \State $t \gets 0$
   \Repeat
     \State   $t \gets t+1$
@@ -263,12 +261,9 @@ Putting everything together, our gradient descent algorithm for ridge regression
 \end{algorithmic}
 \end{algorithm}
 ```
-:::{.column-margin}
-Beware double superscripts!  $\left[ \theta \right]^T$ is the transpose of the vector $\theta$.
-:::
 
 :::{.study-question-callout}
-Is it okay that $\lambda$ doesn't appear in line 8?
+Is it okay that $\lambda$ doesn't appear explicitly in the termination test?
 :::
 
 :::{.study-question-callout}
@@ -303,8 +298,8 @@ $\nabla_\Theta J_i$ for all $i$ in $1\ldots n$. Note that, unlike standard gradi
 
 \begin{algorithm}
 \begin{algorithmic}
-\Procedure{Stochastic-Gradient-Descent}{$\Theta_{init},\eta,\{J_i\}_{i=1}^n,\epsilon$}
-  \State $\Theta^{(0)} \gets \Theta_{\it init}$
+\Procedure{Stochastic-Gradient-Descent}{$\Theta_{\text{init}},\eta,\{J_i\}_{i=1}^n,\epsilon$}
+  \State $\Theta^{(0)} \gets \Theta_{\text{init}}$
   \State $t \gets 0$
   \Repeat
     \State $t \gets t+1$
@@ -322,8 +317,8 @@ Choosing a good stopping criterion can be a little trickier for SGD than traditi
 For SGD to converge to a local optimum point as $t$ increases, the learning rate has to decrease as a function of time. The next result shows one learning rate sequence that works.
 
 :::{#thm-sgd}
- *If $f$ is convex, and $\eta(t)$ is a sequence satisfying $$\sum_{t = 1}^{\infty}\eta(t) = \infty \;\;\text{and}\;\;
-    \sum_{t = 1}^{\infty}\eta(t)^2 < \infty \;\;,$$ then SGD converges *with probability one* to the optimal $\Theta$.*
+ *If $J$ is convex, and $\eta(t)$ is a sequence satisfying $$\sum_{t = 1}^{\infty}\eta(t) = \infty \;\;\text{and}\;\;
+    \sum_{t = 1}^{\infty}\eta(t)^2 < \infty \;\;,$$ then SGD converges with probability one to the optimal $\Theta$.*
 :::
 
 Why these two conditions? The intuition is that the first condition, on $\sum \eta(t)$, is needed to allow for the possibility of an unbounded potential range of exploration, while the second condition, on $\sum\eta(t)^2$, ensures that the learning rates get smaller and smaller as $t$ increases.
@@ -357,8 +352,8 @@ In practice, a common middle ground between GD and SGD is *mini-batch gradient d
 
 \begin{algorithm}
 \begin{algorithmic}
-\Procedure{Mini-batch-Gradient-Descent}{$\Theta_{init},\eta,b,\{J_i\}_{i=1}^n,\epsilon$}
-  \State $\Theta^{(0)} \gets \Theta_{\it init}$
+\Procedure{Mini-batch-Gradient-Descent}{$\Theta_{\text{init}},\eta,b,\{J_i\}_{i=1}^n,\epsilon$}
+  \State $\Theta^{(0)} \gets \Theta_{\text{init}}$
   \State $t \gets 0$
   \Repeat
     \State $t \gets t+1$


### PR DESCRIPTION
Part of a chapter-by-chapter polish pass.

Gradient descent:
- Fix nested-markdown-emphasis bug that leaked literal asterisks into the rendered SGD theorem; also "If f is convex" -> "If J is convex" (f undefined in that section)
- Refer to pseudocode steps by content instead of line number (HTML and PDF renderers number \Procedure differently, so hard-coded line refs are wrong in one of the two)
- Fix study question that used J_ridge as a per-example loss; now asks for the gradient of per-example squared error
- Theorem statement: "global optimum point Theta" -> "global minimum point Theta*"
- Raw || norms -> \lVert \rVert; {\rm arg}\min -> \arg\min; hyphenation and init-subscript consistency; margin note about double superscripts moved next to the display it explains

Classification:
- Study question referenced class -1; the chapter's classes are {+1, 0}
- "Classifiers ... are points" -> "Separators ... are points"
- Literal backtick quotes (``boundary''), R^d -> \mathbb{R}^d, doubled "is"
- LR pseudocode restructured to match the RR block style (drops the lone [H]+caption variant) and fixes the theta^{(t-1)T} double superscript
- {\cal} -> \mathcal, J_{lr} -> J_text{lr}, assorted grammar

Verified: full `quarto render` passes; SGD theorem renders without stray asterisks.