### PR TITLE
Polish features and representation-learning chapters

### DIFF
--- a/feature_representation.qmd
+++ b/feature_representation.qmd
@@ -6,7 +6,7 @@ Linear regression and classification are powerful tools, but in the real world, 
 
 Such behavior is actually ubiquitous in physical systems, e.g., in the vibrations of the surface of a drum, or scattering of light through an aperture. However, no single hyperplane would be a very good fit to such peaked responses!
 
-A richer class of hypotheses can be obtained by performing a non-linear feature transformation $\phi(x)$ before doing the regression. That is, $\theta^Tx + \theta_0$ is a linear function of $x$, but $\theta^T\phi(x) + \theta_0$ is a non-linear function of $x,$ if $\phi$ is a non-linear function of $x$.
+A richer class of hypotheses can be obtained by performing a non-linear feature transformation $\phi(x)$ before doing the regression. That is, $\theta^Tx + \theta_0$ is a linear function of $x$, but $\theta^T\phi(x) + \theta_0$ is a non-linear function of $x$, if $\phi$ is a non-linear function of $x$.
 
 There are many different ways to construct $\phi$. Some are relatively systematic and domain independent. Others are directly related to the semantics (meaning) of the original features, and we construct them deliberately with our application (goal) in mind.
 
@@ -77,7 +77,7 @@ These points are not linearly separable, but consider the transformation $\phi(x
 :::
 :::
 
-A linear separator in $\phi$ space is a non-linear separator in the original space! Let's see how this plays out in our simple example. Consider the separator $x^2  - 1 = 0$ (which corresponds to $\theta = [0,1]^T$ and $\theta_0 = -1$ in our transformed space), which labels the half-plane $x^2 -1 > 0$ as positive. What separator does it correspond to in the original 1-D space? We have to ask the question: which $x$ values have the property that $x^2 - 1 = 0$. The answer is $+1$ and $-1$, so those two points constitute our separator, back in the original space. Similarly, by evaluating where $x^2 - 1 > 0$ and where $x^2 - 1 < 0$, we can find the regions of 1D space that are labeled positive and negative (respectively) by this separator.
+A linear separator in $\phi$ space is a non-linear separator in the original space! Let's see how this plays out in our simple example. Consider the separator $x^2  - 1 = 0$ (which corresponds to $\theta = [0,1]^T$ and $\theta_0 = -1$ in our transformed space), which labels the half-plane $x^2 -1 > 0$ as positive. What separator does it correspond to in the original 1-D space? We have to ask the question: which $x$ values have the property that $x^2 - 1 = 0$? The answer is $+1$ and $-1$, so those two points constitute our separator, back in the original space. Similarly, by evaluating where $x^2 - 1 > 0$ and where $x^2 - 1 < 0$, we can find the regions of 1D space that are labeled positive and negative (respectively) by this separator.
 
 :::{.callout-note}
 ## Example
@@ -127,7 +127,7 @@ Here are two different ways to systematically construct features in a *problem i
 
 ### Polynomial basis {#polyBasis}
 
-If the features in your problem are already naturally numerical, one systematic strategy for constructing a new feature space is to use a *polynomial basis*. The idea is that, if you are using the $k$th-order basis (where $k$ is a positive integer), you include a feature for every possible product of $k$ different dimensions in your original input.
+If the features in your problem are already naturally numerical, one systematic strategy for constructing a new feature space is to use a *polynomial basis*. The idea is that, if you are using the $k$th-order basis (where $k$ is a nonnegative integer), you include a feature for every possible product of at most $k$ original dimensions, with repeats allowed (that is, every monomial of degree at most $k$).
 
 Here is a table illustrating the $k$th order polynomial basis for different values of $k$, calling out the cases when $d=1$ and $d>1$:
 
@@ -154,10 +154,10 @@ The raw data (with $n=1000$ random samples) is plotted on the left, and the regr
 
 Now let's look at a classification example and see how polynomial feature transformation may help us.
 
-One well-known example is the "exclusive or" (xor) data set, the drosophila of machine-learning data sets:
+One well-known example is the "exclusive or" (xor) data set, the *Drosophila* of machine-learning data sets:
 
 :::{.column-margin}
-D. Melanogaster is a species of fruit fly, used as a simple system in which to study genetics, since 1910.
+*D. melanogaster* is a species of fruit fly that has been used as a simple system for studying genetics since 1910.
 :::
 
 :::{.callout-note}
@@ -217,7 +217,7 @@ For fun, we show some more plots below. Here is another result for a linear clas
 ![](figures/feature_representation_xor_order2.png){width="50%" fig-align="center"}
 :::
 
-Here is a harder data set. Logistic regression with gradient descent failed to separate it with a second, third, or fourth-order basis feature representation, but succeeded with a fifth-order basis. Shown below are some results after $\sim1000$ gradient descent iterations (from random starting points) for bases of order 2 (upper left), 3 (upper right), 4 (lower left), and 5 (lower right).
+Here is a harder data set. Logistic regression with gradient descent failed to separate it with a second-, third-, or fourth-order basis feature representation, but succeeded with a fifth-order basis. Shown below are some results after $\sim1000$ gradient descent iterations (from random starting points) for bases of order 2 (upper left), 3 (upper right), 4 (lower left), and 5 (lower right).
 
 :::{.callout-note}
 ## Example
@@ -236,8 +236,8 @@ Here is a harder data set. Logistic regression with gradient descent failed to s
 
 :::{.study-question-callout}
 Percy Eptron has a domain with four numeric input features, $(x_1, \ldots, x_4)$.  He decides to use a representation of the form
-$$\phi(x) = {\rm PolyBasis}((x_1, x_2), 3) ^\frown
-{\rm PolyBasis}((x_3, x_4), 3)$$
+$$\phi(x) = \text{PolyBasis}((x_1, x_2), 3) ^\frown
+\text{PolyBasis}((x_3, x_4), 3)$$
 where $a^\frown b$ means the vector $a$ concatenated with the vector
 $b$.   
 
@@ -256,7 +256,7 @@ The parameter $\beta$ governs how quickly the feature value decays as we move aw
 Now, given a dataset ${\cal D}$ containing $n$ points, we can make a feature transformation $\phi$ that maps points in our original space, $\mathbb{R}^d$, into points in a new space, $\mathbb{R}^n$. It is defined as follows: $$\phi(x) = [f_{x^{(1)}}(x), f_{x^{(2)}}(x), \ldots,
   f_{x^{(n)}}(x)]^T\;\;.$$ So, we represent a new datapoint $x$ in terms of how far it is from each of the datapoints in our training set.
 
-This idea can be generalized in several ways and is the fundamental concept underlying *kernel methods*, that are not directly covered in this class but we recommend you read about sometime. This idea of describing objects in terms of their similarity to a set of reference objects is very powerful and can be applied to cases where $\mathcal{X}$ is not a simple vector space, but where the inputs are graphs or strings or other types of objects, as long as there is a distance metric defined on the input space.
+This idea can be generalized in several ways and is the fundamental concept underlying *kernel methods*, which are not directly covered in this class but which we recommend you read about sometime. This idea of describing objects in terms of their similarity to a set of reference objects is very powerful and can be applied to cases where $\mathcal{X}$ is not a simple vector space, but where the inputs are graphs or strings or other types of objects, as long as there is a distance metric defined on the input space.
 
 ## (Optional) Hand-constructing features for real domains {#handBuiltFeatures}
 
@@ -269,20 +269,20 @@ Getting a good encoding of discrete features is particularly important. You want
 We'll start by listing some encoding strategies, and then work through some examples. Let's assume we have some feature in our raw data that can take on one of $k$ discrete values.
 
 -   **Numeric:** Assign each of these values a number, say $1.0/k,
-              2.0/k, \ldots, 1.0$. We might want to then do some further processing, as described in Section @sec-realFeature. This is a sensible strategy *only* when the discrete values really do signify some sort of numeric quantity, so that these numerical values are meaningful.
+              2.0/k, \ldots, 1.0$. We might want to then do some further processing, as described in @sec-realFeature. This is a sensible strategy *only* when the discrete values really do signify some sort of numeric quantity, so that these numerical values are meaningful.
 
--   **Thermometer code:** If your discrete values have a natural ordering, from $1, \ldots, k$, but not a natural mapping into real numbers, a good strategy is to use a vector of length $k$ binary variables, where we convert discrete input value $0 < j \leq k$ into a vector in which the first $j$ values are $1.0$ and the rest are $0.0$. This does not necessarily imply anything about the spacing or numerical quantities of the inputs, but does convey something about ordering.
+-   **Thermometer code:** If your discrete values have a natural ordering, from $1, \ldots, k$, but not a natural mapping into real numbers, a good strategy is to use a vector of $k$ binary variables, where we convert discrete input value $0 < j \leq k$ into a vector in which the first $j$ values are $1.0$ and the rest are $0.0$. This does not necessarily imply anything about the spacing or numerical quantities of the inputs, but does convey something about ordering.
 
 -   **Factored code:** If your discrete values can sensibly be decomposed into two parts (say the "maker" and "model" of a car), then it's best to treat those as two separate features, and choose an appropriate encoding of each one from this list.
 
 -   **One-hot code:** If there is no obvious numeric, ordering, or factorial structure, then the best strategy is to use a vector of length $k$, where we convert discrete input value $0 < j \leq k$ into a vector in which all values are $0.0$, except for the $j$th, which is $1.0$.
 
--   **Binary code:** It might be tempting for the computer scientists among us to use some binary code, which would let us represent $k$ values using a vector of length $\log k$. *This is a bad idea!* Decoding a binary code takes a lot of work, and by encoding your inputs this way, you'd be forcing your system to *learn* the decoding algorithm.
+-   **Binary code:** It might be tempting for the computer scientists among us to use some binary code, which would let us represent $k$ values using a vector of length $\lceil \log_2 k \rceil$. *This is a bad idea!* Decoding a binary code takes a lot of work, and by encoding your inputs this way, you'd be forcing your system to *learn* the decoding algorithm.
 
 As an example, imagine that we want to encode blood types, that are drawn from the set $\{A+, A-, B+, B-, AB+, AB-, O+, O-\}$. There is no obvious linear numeric scaling or even ordering to this set. But there is a reasonable *factoring*, into two features: $\{A, B, AB,
-  O\}$ and $\{+, -\}$. And, in fact, we can further reasonably factor the first group into $\{A, {\rm not}A\}$, $\{B, {\rm not}B\}$. So, here are two plausible encodings of the whole set:
+  O\}$ and $\{+, -\}$. And, in fact, we can further reasonably factor the first group into $\{A, \text{not } A\}$, $\{B, \text{not } B\}$. So, here are two plausible encodings of the whole set:
 
--   Use a 6-D vector, with two components of the vector each encoding the corresponding factor using a one-hot encoding.
+-   Use a 6-D vector formed by concatenating a one-hot encoding of the first factor $\{A, B, AB, O\}$ (length 4) with a one-hot encoding of the second factor $\{+, -\}$ (length 2).
 
 -   Use a 3-D vector, with one dimension for each factor, encoding its presence as $1.0$ and absence as $-1.0$ (this is sometimes better than $0.0$). In this case, $AB+$ would be $[1.0, 1.0, 1.0]^T$ and $O-$ would be $[-1.0, -1.0, -1.0]^T$.
 
@@ -294,7 +294,7 @@ How would you encode $A+$ in both of these approaches?
 
 The problem of taking a text (such as a tweet or a product review, or even this document!) and encoding it as an input for a machine-learning algorithm is interesting and complicated. Much later in the class, we'll study sequential input models, where, rather than having to encode a text as a fixed-length feature vector, we feed it into a hypothesis word by word (or even character by character!).
 
-There are some simple encodings that work well for basic applications. One of them is the *bag of words* (bow) model, which can be used to encode documents. The idea is to let $d$ be the number of words in our vocabulary (either computed from the training set or some other body of text or dictionary). We will then make a binary vector (with values $1.0$ and $0.0$) of length $d$, where element $j$ has value $1.0$ if word $j$ occurs in the document, and $0.0$ otherwise.
+There are some simple encodings that work well for basic applications. One of them is the *bag of words* (BOW) model, which can be used to encode documents. The idea is to let $d$ be the number of words in our vocabulary (either computed from the training set or some other body of text or dictionary). We will then make a binary vector (with values $1.0$ and $0.0$) of length $d$, where element $j$ has value $1.0$ if word $j$ occurs in the document, and $0.0$ otherwise.
 
 ### Numeric values {#sec-realFeature}
 
@@ -311,4 +311,4 @@ If some feature is already encoded as a numeric value (heart rate, stock price, 
 
 Throughout this chapter, we have treated the feature representation $\phi(x)$ as a fixed pre-processing step that we choose manually to enable linear models to capture non-linear patterns.
 In the next chapter, we will see that neural networks take this a step further: rather than requiring us to specify $\phi(x)$, they *learn* a suitable feature representation directly from data.
-By composing multiple layers of non-linear functions, neural networks can, under some technical conditions, approximate virtually any continuous function. This is a result known as the Universal Approximation Theorem (Cybenko, 1989; Hornik, 1991), which we will not cover in detail in this course but which offers useful insights into why neural networks are so expressive.
+Even with a single hidden layer of non-linear units, neural networks can, under some technical conditions, approximate virtually any continuous function. This is a result known as the Universal Approximation Theorem (Cybenko, 1989; Hornik, 1991), which we will not cover in detail in this course but which offers useful insights into why neural networks are so expressive.

--- a/representation.qmd
+++ b/representation.qmd
@@ -16,7 +16,7 @@ More formally, given data $x \in \mathbb{R}^d$, a representation is a function $
 While representations are often lower-dimensional ($k < d$), this is not required. In many modern systems (e.g., transformers), representations may actually be higher-dimensional, but are structured in a way that makes relevant information easier to extract.
 :::
 
-What makes a representation *good*? Not all compressions are equally useful — a representation that discards the wrong information is worse than useless. Bengio et al. (2013) identify several desirable properties:
+What makes a representation *good*? Not all compressions are equally useful --- a representation that discards the wrong information is worse than useless. Bengio et al. (2013) identify several desirable properties:
 
 1. **Compact** (*minimal*): the representation uses few dimensions, discarding noise and redundancy.
 2. **Explanatory** (*sufficient*): it retains enough information to reconstruct or reason about the original data.
@@ -35,13 +35,13 @@ These properties are sometimes in tension --- for instance, maximizing compactne
 **Representations as embeddings.** Each layer of a neural network maps its input to a vector of *activations*. We can think of this activation vector as an *embedding* --- a point in a high-dimensional space where position encodes meaning. It is important to distinguish between the *weights* of a layer and the *activations* it produces: the weights are the learned parameters (the filters in a CNN, the entries of a weight matrix), while the activations are the outputs produced when those weights are applied to a specific input. The embedding of a data point is its activation vector, not the weights themselves --- the weights define the *mapping* between embedding spaces, while the activations are the *representation* of a particular input at a given level of abstraction. Thus, representation learning can be viewed as learning a geometry over the dataset, where distances and directions encode semantic relationships.
 
 :::{.column-margin}
-In a CNN, the learned filters are the "alphabet" or building blocks of the representation. The embedding of a specific image is the vector of filter activations --- how strongly each filter responds at each location. Two images of the same object will produce similar activation patterns even if their pixels differ substantially. (For example, think of the weights as a dictionary — fixed after training, they define what the network knows how to detect. The activations are the result of looking something up in that dictionary for a specific input. Two images of the same dog produce similar activations (similar lookup results) even if their pixel values differ substantially.)
+In a CNN, the learned filters are the "alphabet" or building blocks of the representation. The embedding of a specific image is the vector of filter activations --- how strongly each filter responds at each location. Two images of the same object will produce similar activation patterns even if their pixels differ substantially. (For example, think of the weights as a dictionary --- fixed after training, they define what the network knows how to detect. The activations are the result of looking something up in that dictionary for a specific input.)
 :::
 
-For example, given an image $x$, the activations at some intermediate layer form a vector that represents the image at a particular level of abstraction. We might call this "im2vec" by analogy with "word2vec" (discussed in @sec-embeddings below). If the network has learned a good representation, then semantically similar images will have embeddings that are close together --- two photos of golden retrievers will be nearby in this space, even if the actual pixel values are very different.
+For example, given an image $x$, the activations at some intermediate layer form a vector that represents the image at a particular level of abstraction. We might call this "im2vec" by analogy with "word2vec" (discussed in @sec-context-embeddings below). If the network has learned a good representation, then semantically similar images will have embeddings that are close together --- two photos of golden retrievers will be nearby in this space, even if the actual pixel values are very different.
 
 
-## Transfer learning and finetuning {#sec-transfer}
+## Transfer learning and fine-tuning {#sec-transfer}
 
 We have already seen representation learning at work, even if we didn't call it that. When a CNN is trained to classify images, its internal layers learn a hierarchy of increasingly abstract features.
 
@@ -61,17 +61,17 @@ If a deep network's internal representations capture general-purpose features (e
 
 1. **Pretrain** a network on a large dataset for task A (e.g., classifying 1000 object categories on ImageNet), obtaining learned parameters $W$ and $b$.
 2. **Transfer** some or all of these parameters to initialize a new network for task B (e.g., recognizing room types from indoor photographs).
-3. **Finetune** the new network on task B's (often much smaller) dataset, resulting in updated parameters $W'$ and $b'$.
+3. **Fine-tune** the new network on task B's (often much smaller) dataset, resulting in updated parameters $W'$ and $b'$.
 
 :::{.column-margin}
 The "learned representation" being transferred is precisely the weights and biases of the pretrained network --- these encode the feature detectors that the network has discovered.
 :::
 
-This works because early layers learn general features (edges, textures) that are useful across many visual tasks, while later layers become increasingly task-specific. Finetuning allows the network to adapt its higher-level representations to the new task while preserving the useful lower-level features. When you finetune, the early layers have already mostly "learned" low-level structure, so gradient updates mostly affect the later layers, which adapt to the new task's semantics. Training from scratch, by contrast, must relearn everything — an expensive and data-hungry process.
+This works because early layers learn general features (edges, textures) that are useful across many visual tasks, while later layers become increasingly task-specific. Fine-tuning allows the network to adapt its higher-level representations to the new task while preserving the useful lower-level features. When you fine-tune, the early layers have already mostly "learned" low-level structure, so most of the useful adaptation happens in the later layers, which adjust to the new task's semantics. Training from scratch, by contrast, must relearn everything --- an expensive and data-hungry process.
 
-Transfer learning is now standard practice in deep learning. Rather than training from scratch, practitioners typically start from a pretrained model and finetune for their specific application. This dramatically reduces the amount of labeled data needed and often yields better results than training from scratch, even with substantial datasets.
+Transfer learning is now standard practice in deep learning. Rather than training from scratch, practitioners typically start from a pretrained model and fine-tune for their specific application. This dramatically reduces the amount of labeled data needed and often yields better results than training from scratch, even with substantial datasets.
 
-In practice, how much of the network to update during finetuning is a design choice. One common strategy is to freeze the early layers entirely (set their gradients to zero) and only train the later layers — this is faster and reduces the risk of overwriting useful low-level features. As a rule of thumb: the more similar task B is to task A, the more layers you can safely freeze.
+In practice, how much of the network to update during fine-tuning is a design choice. One common strategy is to freeze the early layers entirely (exclude their weights from the gradient updates) and only train the later layers --- this is faster and reduces the risk of overwriting useful low-level features. As a rule of thumb: the more similar task B is to task A, the more layers you can safely freeze.
 
 
 ## Learning representations without labels
@@ -85,7 +85,7 @@ There is reason to think we can. The key insight of *self-supervised learning* i
 
 The idea behind *self-supervised learning* is conceptually simple: instead of requiring human-provided labels, we create a supervised learning problem *from the data itself*, using the structure of the data to generate labels automatically.
 
-The key idea is to design a *pretext task* --- an auxiliary prediction problem whose labels are free. By training a network to solve the pretext task, useful representations emerge in its internal layers. This is a natural extension of the supervised learning students are already familiar with --- the only difference is *where the labels come from*.
+The key idea is to design a *pretext task* --- an auxiliary prediction problem whose labels are free. By training a network to solve the pretext task, useful representations emerge in its internal layers. This is a natural extension of the supervised learning you are already familiar with --- the only difference is *where the labels come from*.
 
 Examples of pretext tasks include:
 
@@ -120,11 +120,11 @@ $$a^T b = a \cdot b = \sum_{j} a_j \, b_j$$
 A related measure is *cosine similarity*, $\frac{a^T b}{\|a\| \, \|b\|}$, which normalizes for vector magnitude and measures only directional alignment.
 :::
 
-The inner product indicates how aligned two vectors are: highly positive values imply strong similarity, negative values indicate opposition, and values near zero suggest no similarity (up to a scaling factor related to the magnitude).
+The inner product indicates how aligned two vectors are: highly positive values imply strong similarity, negative values indicate opposition, and values near zero suggest little alignment. (The inner product also grows with the vectors' magnitudes; cosine similarity, shown in the margin, normalizes this away.)
 
 A groundbreaking embedding method, *word2vec* (Mikolov et al., 2013), produced embeddings where vector arithmetic corresponds to semantic relationships:
 
-$$\text{embedding}_{\tt paris} - \text{embedding}_{\tt france} + \text{embedding}_{\tt italy} \approx \text{embedding}_{\tt rome}$$
+$$\text{embedding}_{\texttt{paris}} - \text{embedding}_{\texttt{france}} + \text{embedding}_{\texttt{italy}} \approx \text{embedding}_{\texttt{rome}}$$
 
 Such embeddings revealed meaningful semantic relationships like analogies across diverse vocabulary (e.g., $\textit{uncle} - \textit{man} + \textit{woman} \approx \textit{aunt}$). The training procedure is a form of self-supervised learning: the network learns to predict a word from its context (or vice versa), and the word vectors that emerge from this training capture distributional semantics --- the principle that "you shall know a word by the company it keeps."
 
@@ -166,10 +166,10 @@ Zero-shot means the model can handle categories it was never explicitly trained 
 
 A special case of self-supervised learning arises when the pretext task is to reconstruct the input $x$ *itself* --- not a masked portion, not a neighboring patch, but the entire input. When this reconstruction is forced through a bottleneck, the result is an *autoencoder*, and the latent representation at the bottleneck becomes very explicit.
 
-In a simple, linearly connected network (without residual connections or separate convolution streams), we can think of the activations at an intermediate layer as the latent representation. The autoencoder makes this idea precise: the network is clamped to produce itself, and the bottleneck enforces an *information constraint* that forces a compressed encoding capturing the essential structure of the data.
+In a simple, linearly connected network (without residual connections or separate convolution streams), we can think of the activations at an intermediate layer as the latent representation. The autoencoder makes this idea precise: the network is trained to reproduce its own input, and the bottleneck enforces an *information constraint* that forces a compressed encoding capturing the essential structure of the data.
 
 Assume that we have input data $\mathcal{D} = \{x^{(1)}, \ldots,
-  x^{(n)} \}$, where $x^{(i)}\in \mathbb{R}^d$. We seek to learn an autoencoder that will produce a new dataset $\mathcal{D}_{out} =
+  x^{(n)} \}$, where $x^{(i)}\in \mathbb{R}^d$. We seek to learn an autoencoder that will produce a new dataset $\mathcal{D}_{\text{out}} =
   \{a^{(1)}, \ldots, a^{(n)}\}$, where $a^{(i)}\in \mathbb{R}^k$ with $k
   < d$. We can think about $a^{(i)}$ as the new *representation* of data point $x^{(i)}$. For example, in @fig-illustration we show the learned representations of a dataset of MNIST digits with $k=2$. We see, after inspecting the individual data points, that unsupervised learning has found a compressed (or *latent*) representation where images of the same digit are close to each other, potentially greatly aiding subsequent clustering or classification tasks.
 
@@ -179,19 +179,19 @@ Assume that we have input data $\mathcal{D} = \{x^{(1)}, \ldots,
   \mathbb{R}^k$, and a *decoder* $h : \mathbb{R}^k \rightarrow
   \mathbb{R}^d$ that maps the representation space back into the original data space.
 
-The encoder and decoder are typically neural networks. The basic architecture of a single-layer autoencoder is shown in @fig-autoencoder; note that bias terms $W^1_0$ and $W^2_0$ into the summation nodes exist, but are omitted for clarity in the figure. The original $d$-dimensional input is compressed into $k$ dimensions via the encoder $g(x; W^1, W^1_0)=f_1(W{^1}^T x + W^1_0)$ with $W^1 \in
-  \mathbb{R}^{d \times k}$ and $W^1_0 \in \mathbb{R}^k$, where the non-linearity $f_1$ is applied element-wise. To recover (an approximation to) the original instance, we then apply the decoder $h(a; W^2, W^2_0) = f_2(W{^2}^T
+The encoder and decoder are typically neural networks. The basic architecture of a single-layer autoencoder is shown in @fig-autoencoder; note that bias terms $W^1_0$ and $W^2_0$ into the summation nodes exist, but are omitted for clarity in the figure. The original $d$-dimensional input is compressed into $k$ dimensions via the encoder $g(x; W^1, W^1_0)=f_1({W^1}^T x + W^1_0)$ with $W^1 \in
+  \mathbb{R}^{d \times k}$ and $W^1_0 \in \mathbb{R}^k$, where the non-linearity $f_1$ is applied element-wise. To recover (an approximation to) the original instance, we then apply the decoder $h(a; W^2, W^2_0) = f_2({W^2}^T
   a + W^2_0)$, where $f_2$ denotes a different activation function. In general, both the encoder and decoder could involve multiple layers. Learning seeks parameters $W^1, W^1_0$ and $W^2, W^2_0$ such that the reconstructed instances, $h(g(x^{(i)}; W^{1}, W^1_0); W^{2}, W^2_0)$, are close to the original input $x^{(i)}$.
 
 ![Autoencoder structure, showing the encoder (left half, light green), and the decoder (right half, light blue), encoding inputs $x$ to the representation $a$, and decoding the representation to produce $\tilde{x}$, the reconstruction. In this specific example, the representation ($a_1$, $a_2$, $a_3$) only has three dimensions.](figures/autoencoder.png){#fig-autoencoder width="60%"}
 
-**Learning.** We learn the weights using the same tools from supervised learning: (stochastic) gradient descent to minimize a loss function. The loss $\mathcal{L}(\tilde{x}, x)$ measures the discrepancy between the reconstruction $\tilde{x} = h(g(x; W^{1}, W^1_0); W^{2}, W^2_0)$ and the original input $x$. For continuous-valued $x$, a natural choice is squared loss: $\mathcal{L}_{SE}(\tilde{x}, x) = \sum_{j=1}^{d} (x_j - \tilde{x}_j)^2$.
+**Learning.** We learn the weights using the same tools from supervised learning: (stochastic) gradient descent to minimize a loss function. The loss $\mathcal{L}(\tilde{x}, x)$ measures the discrepancy between the reconstruction $\tilde{x} = h(g(x; W^{1}, W^1_0); W^{2}, W^2_0)$ and the original input $x$. For continuous-valued $x$, a natural choice is squared loss: $\mathcal{L}_{\text{SE}}(\tilde{x}, x) = \sum_{j=1}^{d} (x_j - \tilde{x}_j)^2$.
 
 :::{.column-margin}
 Alternatively, you could think of this as *multi-task learning*, where the goal is to predict each dimension of $x$. One can mix-and-match loss functions as appropriate for each dimension's data type.
 :::
 
-Learning then seeks to optimize the parameters of $h$ and $g$ so as to minimize the reconstruction error: $$\min_{W^{1}, W^1_0, W^{2}, W^2_0} \sum_{i=1}^n \mathcal{L}_{SE}\left(h(g(x^{(i)}; W^{1}, W^1_0); W^{2}, W^2_0), x^{(i)}\right)$$
+Learning then seeks to optimize the parameters of $h$ and $g$ so as to minimize the reconstruction error: $$\min_{W^{1}, W^1_0, W^{2}, W^2_0} \sum_{i=1}^n \mathcal{L}_{\text{SE}}\left(h(g(x^{(i)}; W^{1}, W^1_0); W^{2}, W^2_0), x^{(i)}\right)$$
 
 **The importance of the bottleneck.** Without further constraints, it is always possible to perfectly reconstruct the input --- for example, by letting $k=d$ and using identity functions. To learn something useful, we must create a *bottleneck* by making $k$ smaller (often much smaller) than $d$. This forces the learning algorithm to discover transformations that describe the original data using as simple a description as possible. For the digits dataset, a compressed representation might capture the digit label (0--9), rotation, and stroke thickness. After learning, we can inspect the learned representations --- for example, by varying one dimension of $a$ and observing how the decoded output $h(a)$ changes --- to understand what the autoencoder has learned.
 
@@ -201,10 +201,10 @@ If we set $k = d$ (the bottleneck has the same dimension as the input), what wou
 
 **Linear encoders and PCA.** Even linear encoders and decoders can be powerful. When both $f_1$ and $f_2$ are the identity function, the optimal solution can be obtained in closed form via *principal components analysis* (PCA) using singular value decomposition (SVD). The neural network autoencoders discussed above can be thought of as nonlinear generalizations of PCA, just as a multilayer neural network for regression generalizes linear regression.
 
-**From compression to downstream tasks.** Once a good encoder has been learned, the decoder can be discarded and the encoder used as a feature extractor. The representations $a = g(x)$ can then be fed into a classifier or regressor trained with supervised learning --- potentially using a much smaller labeled dataset. This connects autoencoders to the semi-supervised learning setting described in @sec-self-supervised: we use a large unlabeled dataset to learn the representation and a small labeled dataset for the downstream task.
+**From compression to downstream tasks.** Once a good encoder has been learned, the decoder can be discarded and the encoder used as a feature extractor. The representations $a = g(x)$ can then be fed into a classifier or regressor trained with supervised learning --- potentially using a much smaller labeled dataset. This gives a *semi-supervised* recipe, mirroring the pretext-task idea of @sec-self-supervised: we use a large unlabeled dataset to learn the representation and a small labeled dataset for the downstream task.
 
 
-## Embeddings: a unifying view {#sec-embeddings}
+## Embeddings: a unifying view {#sec-embeddings-view}
 
 The representations learned by all the methods above are, at their core, *embeddings*: mappings from complex, high-dimensional data (images, words, sentences, graphs) into vectors in a lower-dimensional space. The key property of a good embedding is that **geometric relationships in the vector space reflect meaningful relationships in the original data**.
 


### PR DESCRIPTION
Part of a chapter-by-chapter polish pass.

Feature representation:
- Fix "Section Section 5.3.3" double prefix (Quarto already prepends "Section" to @refs)
- Correct the polynomial-basis definition (monomials of degree at most k, repeats allowed; previously said "products of k different dimensions", contradicting the chapter's own table)
- Clarify the blood-type one-hot encoding as two concatenated one-hot blocks
- Universal-approximation claim now matches the cited single-hidden-layer theorem
- Assorted typos and LaTeX style ({\rm} -> \text, BOW, Drosophila)

Representation learning:
- Rename duplicate #sec-embeddings anchor to #sec-embeddings-view; it collided with transformers.qmd's anchor, so the word2vec cross-ref linked to the wrong chapter. The ref now targets #sec-context-embeddings where word2vec actually lives
- Fix malformed W{^1}^T transpose LaTeX in the autoencoder equations
- Reader-facing voice ("you" instead of "students"), accurate freezing/fine-tuning descriptions, fine-tuning spelling standardized
- Deduplicate margin note / parenthetical, notation cleanup (L_SE, D_out, \tt -> \texttt)

Verified: full `quarto render` passes; the word2vec link now resolves within the chapter.