### PR TITLE
Polish non-parametric and MDP chapters

### DIFF
--- a/mdp.qmd
+++ b/mdp.qmd
@@ -27,7 +27,7 @@ The notation $S_t = s'$ uses a capital letter $S$ to stand for
 
 -   $\mathrm{R}: \mathcal S \times \mathcal A \rightarrow \mathbb{R}$ is a *reward function*, where $\mathrm{R}(s, a)$ specifies an immediate reward for taking action $a$ when in state $s$; and
 
--   $\gamma \in [0, 1]$ is a *discount factor* that down-weights future rewards, which we'll discuss in @sec-mdp_infinite_horizon.
+-   $\gamma \in [0, 1)$ is a *discount factor* that down-weights future rewards, which we'll discuss in @sec-mdp_infinite_horizon.
 
 :::{.column-margin}
 The standard assumption is $0 \leq \gamma < 1$. Setting $\gamma = 1$ (no discounting) can be problematic in the infinite-horizon setting, causing returns to diverge or become ill-defined. 
@@ -69,7 +69,7 @@ For each action, this is what is done to the object:
 These descriptions specify the transition model $\mathrm{T}$, and the transition function for each action can be depicted as a state machine diagram. For example, here is the diagram for `wash`:
 
 :::{.imagify}
-\begin{tikzpicture}[-> background rectangle/.style={fill=white}, show background rectangle]
+\begin{tikzpicture}[->, background rectangle/.style={fill=white}, show background rectangle]
   \node[state] (dirty) {dirty};
   \node[state, right of=dirty, xshift=2.5cm] (clean) {clean};
   \node[state, below of=dirty, yshift=-2.5cm] (painted) {painted};
@@ -79,7 +79,7 @@ These descriptions specify the transition model $\mathrm{T}$, and the transition
   (clean) edge[loop above] node{0.9} (clean)
   (clean) edge[bend left, below] node{0.1} (dirty)
   (painted) edge[left] node{0.1} (dirty)
-  (painted) edge[right] node{~0.9} (clean)
+  (painted) edge[right] node{0.9} (clean)
   (ejected) edge[loop above] node{1.0} (ejected);
 \end{tikzpicture}
 :::
@@ -90,7 +90,7 @@ These descriptions specify the transition model $\mathrm{T}$, and the transition
   completed by also specifying a discount factor.
 :::
 
-A *policy* is a function $\pi$ that specifies what action to take in each state. The policy is what we will want to learn; it is akin to the strategy that a player employs to win a given game. Below, we take just the initial steps towards this eventual goal. We describe how to evaluate how good a policy is, first in the *finite horizon* case @sec-mdp_finite_horizon when the total number of transition steps is finite. In the finite horizon case, we typically denote the policy as $\pi_h(s)$, where $h$ is a non-negative integer denoting the number of steps remaining and $s \in \mathcal S$ is the current state. Then we consider the *infinite horizon* case @sec-mdp_infinite_horizon, when you don't know when the game will be over.
+A *policy* is a function $\pi$ that specifies what action to take in each state. The policy is what we will want to learn; it is akin to the strategy that a player employs to win a given game. Below, we take just the initial steps towards this eventual goal. We describe how to evaluate how good a policy is, first in the *finite horizon* case (@sec-mdp_finite_horizon), when the total number of transition steps is finite. In the finite horizon case, we typically denote the policy as $\pi_h(s)$, where $h$ is a non-negative integer denoting the number of steps remaining and $s \in \mathcal S$ is the current state. Then we consider the *infinite horizon* case (@sec-mdp_infinite_horizon), when you don't know when the game will be over.
 
 ### Finite-horizon value functions   {#sec-mdp_finite_horizon}
 
@@ -136,7 +136,7 @@ Then we can say that a policy $\pi$ is better than policy $\bar{\pi}$ for horizo
 
 ### Infinite-horizon value functions {#sec-mdp_infinite_horizon}
 
-More typically, the actual finite horizon is not known, i.e., when you don't know when the game will be over! When we model decision-making without a fixed terminal time, we use the *infinite-horizon* setting. How does one evaluate the goodness of a policy in the infinite horizon case?
+More typically, there is no known, fixed horizon: you don't know when the game will be over! When we model decision-making without a fixed terminal time, we use the *infinite-horizon* setting. How does one evaluate the goodness of a policy in the infinite horizon case?
 
 If we tried to simply take our definitions above and use them for an infinite horizon, we could get in trouble. Imagine we get a reward of 1 at each step under one policy and a reward of 2 at each step under a different policy. Then the reward as the number of steps grows in each case keeps growing to become infinite in the limit of more and more steps. Even though it seems intuitive that the second policy should be better, we can't justify that by saying $\infty < \infty$.
 
@@ -152,7 +152,7 @@ where $\mathrm{R}_t$ is the reward received at time $t$.
 # Note
 What is $\mathbb{E}\left[ \cdot \right ]$? This mathematical notation indicates an *expectation*, i.e., an average taken over all the random possibilities which may occur for the argument. Here, the expectation is taken over the *conditional probability* $\Pr(\mathrm{R}_t = r \mid \pi, s_0)$, where $\mathrm{R}_t$ is the random variable for the reward, subject to the policy being $\pi$ and the state being $s_0$. Since $\pi$ is a function, this notation is shorthand for conditioning on all of the random variables implied by policy $\pi$ and the stochastic transitions of the MDP.
 
-A very important point is that $\mathrm{R}(s,a)$ is always deterministic (in this class) for any given $s$ and $a$. Here $\mathrm{R}_t$ represents the set of all possible $\mathrm{R}(s_t,a)$ at time step $t$; this $\mathrm{R}_t$ is a random variable because the state we're in at step $t$ is itself a random variable, due to prior stochastic state transitions up to but not including at step $t$ and prior (deterministic) actions dictated by policy $\pi.$
+A very important point is that $\mathrm{R}(s,a)$ is always deterministic (in this class) for any given $s$ and $a$. Here $\mathrm{R}_t$ is the reward $\mathrm{R}(S_t, A_t)$ received at step $t$; it is a random variable because the state at step $t$ is itself random, due to prior stochastic state transitions up to but not including step $t$ and prior (deterministic) actions dictated by policy $\pi.$
 :::
 
 Now, for the infinite-horizon case, we typically select a discount factor $0 \leq \gamma < 1$, and evaluate a policy based on its expected *infinite horizon value*: 
@@ -165,7 +165,7 @@ $${#eq-exp_infinite}
 Note that the $t$ indices here are not the number of steps to go, but actually the number of steps forward from the starting state (there is no sensible notion of "steps to go" in the infinite horizon case).
 
 :::{.callout-note}
-@eq-exp_finite and @eq-exp_infinite are a conceptual stepping stone. @eq-inf_horiz_value is the infinite-horizon analogue of @eq-finite_value.
+@eq-exp_finite and @eq-exp_infinite serve as a conceptual stepping stone. @eq-inf_horiz_value is the infinite-horizon analogue of @eq-finite_value.
 :::
 
 There are two good intuitive motivations for discounting. One is related to economic theory and the present value of money: you'd generally rather have some money today than that same amount of money next week (because you could use it now or invest it). The other is to think of the whole process terminating, with probability $1-\gamma$ on each step of the interaction. (At every
@@ -184,7 +184,7 @@ $$
 \mathrm{V}_{\infty}^{\pi}(s) &= \mathbb{E}[\mathrm{R}_0 + \gamma \mathrm{R}_1 + \gamma^2 \mathrm{R}_2 +
     \dots \mid \pi, S_0 = s] \\
     &= \mathbb{E}[\mathrm{R}_0 + \gamma(\mathrm{R}_1 + \gamma(\mathrm{R}_2 + \gamma
-    \dots))) \mid \pi, S_0 = s] \;\;.
+    \dots)) \mid \pi, S_0 = s] \;\;.
 \end{align}
 $${#eq-vpi-expanded} 
 
@@ -193,7 +193,7 @@ Because the expectation of a linear combination of random variables is the linea
 
 $$\begin{aligned}
   \mathrm{V}_{\infty}^{\pi}(s) & = \mathbb{E}[\mathrm{R}_0 \mid \pi, S_0 = s] + \gamma  \mathbb{E}[
-    \mathrm{R}_1 + \gamma(\mathrm{R}_2 + \gamma \dots))) \mid \pi, S_0 = s]
+    \mathrm{R}_1 + \gamma(\mathrm{R}_2 + \gamma \dots) \mid \pi, S_0 = s]
   \nonumber
   \\
              & = \mathrm{R}(s, \pi(s)) + \gamma\sum_{s'}\mathrm{T}(s, \pi(s), s')\mathrm{V}_{\infty}^{\pi}(s') \; .
@@ -205,7 +205,7 @@ This is *so* cool!  In a discounted model, if you find that you survived this ro
 function that is relevant in that state is exactly the same one as in state $s$.
 :::
 
-The equation defined in @eq-inf_horiz_value is known as the Bellman Equation, which breaks down the value function into the immediate reward and the (discounted) future value function. You could write down one of these equations for each of the $n = |\mathcal S|$ states. There are $n$ unknowns $\mathrm{V}^{\pi}(s)$. These are linear equations, and standard software (e.g., using Gaussian elimination or other linear algebraic methods) will, in most cases, enable us to find the value of each state under this policy.
+The equation defined in @eq-inf_horiz_value is known as the Bellman Equation, which breaks down the value function into the immediate reward and the (discounted) future value function. You could write down one of these equations for each of the $n = |\mathcal S|$ states. There are $n$ unknowns $\mathrm{V}_{\infty}^{\pi}(s)$. These are linear equations, and since $\gamma < 1$ the system has a unique solution, which standard linear-algebraic methods (e.g., Gaussian elimination) will find.
 
 ## Finding policies for MDPs {#sec-finding_mdp_policies}
 
@@ -255,10 +255,10 @@ $$
 \mathrm{Q}^{\pi}_h(s,\pi_h(s)) = \mathrm{V}^{\pi}_h(s).
 $$
 
-However, since our primary goal in dealing with action values is typically to identify an *optimal* policy, we will not dwell extensively on ($\mathrm{Q}^{\pi}_h(s,a)$). Instead, we will place more emphasis on the optimal action-value functions $\mathrm{Q}^{*}_h(s,a)$.
+However, since our primary goal in dealing with action values is typically to identify an *optimal* policy, we will not dwell extensively on $\mathrm{Q}^{\pi}_h(s,a)$. Instead, we will place more emphasis on the optimal action-value functions $\mathrm{Q}^{*}_h(s,a)$.
 :::
 
-Similar to our definition of $\mathrm{V}_h^{*}$ for evaluating a policy, we define the $\mathrm{Q}_h^{*}$ function recursively according to the horizon. The only difference is that, on each step with horizon $h$, rather than selecting an action specified by a given policy, we select the value of $a$ that will maximize the expected $\mathrm{Q}_h^{*}$ value of the next state. 
+Similar to our definition of $\mathrm{V}_h^{\pi}$ for evaluating a policy, we define the $\mathrm{Q}_h^{*}$ function recursively according to the horizon. The only difference is that, on each step with horizon $h$, rather than selecting an action specified by a given policy, we take, at the next state $s'$, the action $a'$ that maximizes $\mathrm{Q}_{h-1}^{*}(s', a')$.
 
 $$\begin{aligned}
   \mathrm{Q}_0^{*}(s, a) & = 0                                                                 \\
@@ -269,7 +269,7 @@ $$\begin{aligned}
   \mathrm{Q}_h^{*}(s, a) & = \mathrm{R}(s, a) + \gamma \sum_{s'}\mathrm{T}(s, a, s') \max_{a'} \mathrm{Q}_{h - 1}^{*}(s', a')
 \end{aligned}
 $$ 
-where $(s',a')$ denotes the next time-step state/action pair. We can solve for the values of $\mathrm{Q}_h^{*}$ with a simple recursive algorithm called *finite-horizon value iteration* that just computes $\mathrm{Q}_h^{*}$ starting from horizon 0 and working backward to the desired horizon $h$. Given $\mathrm{Q}_h^{*}$, an optimal $\pi_h^*$ can be found as follows: $$\pi_h^*(s) = \arg\max_{a}\mathrm{Q}_h^{*}(s, a) \;\;.$$ which gives the *immediate* best action(s) to take when there are $h$ steps left; then $\pi_{h-1}^*(s)$ gives the best action(s) when there are $(h-1)$ steps left, and so on. In the case where there are multiple best actions, we typically can break ties randomly.
+where $(s',a')$ denotes the next time-step state/action pair. We can solve for the values of $\mathrm{Q}_h^{*}$ with a simple recursive algorithm called *finite-horizon value iteration* that just computes $\mathrm{Q}_h^{*}$ starting from horizon 0 and working backward to the desired horizon $h$. Given $\mathrm{Q}_h^{*}$, an optimal $\pi_h^*$ can be found as follows: $$\pi_h^*(s) = \arg\max_{a}\mathrm{Q}_h^{*}(s, a) \;\;,$$ which gives the *immediate* best action(s) to take when there are $h$ steps left; then $\pi_{h-1}^*(s)$ gives the best action(s) when there are $(h-1)$ steps left, and so on. In the case where there are multiple best actions, we can typically break ties randomly.
 
 Additionally, it is worth noting that in order for such an optimal policy to be computed, we assume that the reward function $\mathrm{R}(s,a)$ is bounded on the set of all possible (state, action) pairs. Furthermore, we will assume that the set of all possible actions is finite.
 
@@ -325,7 +325,7 @@ We can iteratively solve for the $\mathrm{Q}^*$ values with the infinite-horizon
 \begin{algorithm}
 \caption{Infinite-Horizon-Value-Iteration}
 \begin{algorithmic}[1]
-\REQUIRE $\mathcal{S}$, $\mathcal{A}$, $T$, $R$, $\gamma$, $\epsilon$
+\REQUIRE $\mathcal{S}$, $\mathcal{A}$, $\mathrm{T}$, $\mathrm{R}$, $\gamma$, $\epsilon$
 \STATE \textbf{Initialization:}
 \FOR{each $s \in \mathcal{S}$ and $a \in \mathcal{A}$}
     \STATE $\mathrm{Q}_{\text{old}}(s,a) \gets 0$
@@ -343,19 +343,19 @@ We can iteratively solve for the $\mathrm{Q}^*$ values with the infinite-horizon
 \end{algorithm}
 ```
 
-##### Theory {#theory .unnumbered}
+#### Theory {.unnumbered}
 
 There are a lot of nice theoretical results about infinite-horizon value iteration. For some given (not necessarily optimal) $\mathrm{Q}$ function, define $\pi_{\mathrm{Q}}(s) = \arg\max_{a}\mathrm{Q}(s, a)$.
 
--   After infinite-horizon value iteration stops with $\Vert \mathrm{Q}_{\text{old}} - \mathrm{Q}_{\text{new}} \rVert_{\infty} < \epsilon$, $$\lVert  \mathrm{V}^{\pi_{\mathrm{Q}_{\text{new}}}} - \mathrm{V}^{\pi^*} \rVert_{\infty} \le \frac{2\gamma\epsilon}{(1-\gamma)^2}\;\; . $$
+-   After infinite-horizon value iteration stops with $\lVert \mathrm{Q}_{\text{old}} - \mathrm{Q}_{\text{new}} \rVert_{\infty} < \epsilon$, $$\lVert  \mathrm{V}^{\pi_{\mathrm{Q}_{\text{new}}}} - \mathrm{V}^{\pi^*} \rVert_{\infty} \le \frac{2\gamma\epsilon}{(1-\gamma)^2}\;\; . $$
 
 :::{.column-margin}
 Recall that the infinity norm returns the largest absolute value of an element in the vector.
 :::
--   If every state has a unique optimal action and the optimal action-gap is uniformly positive ($\Delta(s) = Q^*(s, a^*) - \max_{a \neq a^*} Q^*(s, a) > 0$), then there is a value of $\epsilon$ such that 
-$$\Vert \mathrm{Q}_{\text{old}} - \mathrm{Q}_{\text{new}} \rVert_{\infty} < \epsilon \Longrightarrow \pi_{\mathrm{Q}_{\text{new}}} = \pi^*
+-   If every state has a unique optimal action and the optimal action-gap is uniformly positive ($\Delta(s) = \mathrm{Q}^*(s, a^*) - \max_{a \neq a^*} \mathrm{Q}^*(s, a) > 0$), then there is a value of $\epsilon$ such that 
+$$\lVert \mathrm{Q}_{\text{old}} - \mathrm{Q}_{\text{new}} \rVert_{\infty} < \epsilon \Longrightarrow \pi_{\mathrm{Q}_{\text{new}}} = \pi^*
 $$
 
--   As the algorithm executes, $\lVert \mathrm{Q}_{\text{new}} - \mathrm{Q}^{*} \Vert_{\infty}$ decreases monotonically on each iteration.
+-   As the algorithm executes, $\lVert \mathrm{Q}_{\text{new}} - \mathrm{Q}^{*} \rVert_{\infty}$ decreases monotonically on each iteration.
 
 -   The algorithm can be executed asynchronously, in parallel: as long as all $(s, a)$ pairs are updated infinitely often in an infinite run, it still converges to the optimal value.

--- a/non_parametric.qmd
+++ b/non_parametric.qmd
@@ -1,6 +1,6 @@
 # Non-parametric Models {#sec-nonparametric}
 
-Neural networks have adaptable complexity in the sense that we can try different architectures and use cross-validation to pick one that works well on our data. In this chapter we turn to models that adapt their complexity *automatically* to the training data: the name *non-parametric* is misleading: these methods do have parameters, but the size of the parameterization can grow as we acquire more data, rather than being fixed in advance.
+Neural networks have adaptable complexity in the sense that we can try different architectures and use cross-validation to pick one that works well on our data. In this chapter we turn to models that adapt their complexity *automatically* to the training data. The name *non-parametric* is misleading: these methods do have parameters, but the size of the parameterization can grow as we acquire more data, rather than being fixed in advance.
 
 The methods we consider here tend to have the form of a composition of simple models:
 
@@ -19,12 +19,16 @@ Even in the era of large neural networks, these methods are worth knowing: they 
 In nearest-neighbor models, we don't do any processing of the data at training time -- we just remember it! All the work is done at prediction time.
 
 Input values $x$ can be from any domain $\mathcal X$ ($\mathbb{R}^d$, documents, tree-structured objects, etc.). We just need a distance metric, $d: \mathcal X \times \mathcal X
-  \rightarrow \mathbb{R}^+$, which satisfies the following, for all $x, x', x'' \in
+  \rightarrow \mathbb{R}^{\geq 0}$, which satisfies the following, for all $x, x', x'' \in
   \mathcal X$: $$\begin{aligned}
   d(x, x)   & = 0                        \\
   d(x, x')  & = d(x', x)                 \\
   d(x, x'') & \leq d(x, x') + d(x', x'')
 \end{aligned}$$
+
+:::{.column-margin}
+We reuse $d$ for the distance function here; context distinguishes it from the input dimension $d$.
+:::
 
 Given a dataset $\mathcal{D}= \{(x^{(i)},y^{(i)})\}_{i=1}^n$, our predictor for a new query $x \in \mathcal X$ is $$h(x) = y^{(i^*)} \quad \text{where} \quad i^* = \arg\min_i d(x, x^{(i)}),$$ with ties broken at random.
 
@@ -34,7 +38,7 @@ Geometrically, this partitions the input space into a *Voronoi diagram*: one reg
 
 ![Voronoi diagram: each region contains the points closest to one training example.](figures/voronoi.png){width="40%" fig-align="center"}
 
-There are several useful variations on this method. In *$k$-nearest-neighbors*, we find the $k$ training points nearest to the query point $x$ and output the majority $y$ value for classification or the average for regression. We can also do *locally weighted regression* in which we fit locally linear regression models to the $k$ nearest points, possibly giving less weight to those that are farther away. In large data-sets, it is important to use good data structures (e.g., ball trees) to perform the nearest-neighbor look-ups efficiently (without looking at all the data points each time).
+There are several useful variations on this method. In *$k$-nearest-neighbors*, we find the $k$ training points nearest to the query point $x$ and output the majority $y$ value for classification or the average for regression. We can also do *locally weighted regression* in which we fit locally linear regression models to the $k$ nearest points, possibly giving less weight to those that are farther away. In large datasets, it is important to use good data structures (e.g., ball trees) to perform the nearest-neighbor look-ups efficiently (without looking at all the data points each time).
 
 ## $k$-means Clustering {#sec-clustering}
 *Clustering* is the problem of automatically discovering meaningful groupings in a dataset, without pre-assigned labels. A doctor may notice that their patients come in cohorts that respond differently to different treatments; a biologist may identify that bats and whales, despite outward appearances, both belong to the same category ("mammal"). Once such groupings are found, they can be used to interpret the data and to make decisions per group.
@@ -68,7 +72,7 @@ $${#eq-kmeans_obj}
 
 where $\mu^{(j)} = \frac{1}{N_j} \sum_{i=1}^n \mathbb{1}(y^{(i)} = j) x^{(i)}$ is the mean of cluster $j$, $N_j = \sum_i \mathbb{1}(y^{(i)} = j)$ is its size, and $\mathbb{1}(\cdot)$ is the indicator function. Each inner sum is one cluster's within-cluster variance; the outer sum totals these across all $k$ clusters.
 
-The k-means algorithm minimizes this loss by alternating two steps: (1) reassign each datapoint to the cluster with the nearest mean, and (2) recompute each cluster mean from the points now assigned to it. Both steps are non-increasing in the loss, so the algorithm converges. @fig-kmeans_iters shows the first three iterations on our toy dataset; @fig-kmeans_converged shows the converged result after four iterations.
+The k-means algorithm minimizes this loss by alternating two steps: (1) reassign each datapoint to the cluster with the nearest mean, and (2) recompute each cluster mean from the points now assigned to it. Neither step can increase the loss, so the algorithm converges. @fig-kmeans_iters shows the first three iterations on our toy dataset; @fig-kmeans_converged shows the converged result after four iterations.
 
 ![The first three steps of running the k-means algorithm on this data. Datapoints are colored according to the cluster to which they are assigned. Cluster means are the larger X's with black outlines.](figures/kmeans_iters.png){#fig-kmeans_iters width="100%"}
 
@@ -109,7 +113,7 @@ In full detail:
 
 #### Using gradient descent to minimize the k-means objective
 
-We can also use gradient descent. Rewrite the objective as a differentiable function of $\mu$ alone, by choosing the optimal assignment for each point on the fly:
+We can also use gradient descent. Rewrite the objective as a function of $\mu$ alone (differentiable except where a point is equidistant from two centroids), by choosing the optimal assignment for each point on the fly:
 $$L(\mu) = \sum_{i=1}^n \min_j \lVert x^{(i)} - \mu^{(j)} \rVert^2.$$
 Run gradient descent on $L(\mu)$, then read off the cluster assignments from the optimized $\mu$:
 $$y^{(i)} = \arg\min_j \lVert x^{(i)} - \mu^{(j)} \rVert^2.$$
@@ -125,16 +129,16 @@ Both variants only converge to a local minimum, so the result depends on the ini
 
 A variety of methods have been developed to pick good initializations (see, for example, the *k-means++* algorithm). One simple option is to run the standard k-means algorithm multiple times, with different random initial conditions, and then pick from these the clustering that achieves the lowest k-means loss.
 
-#### Importance of k {#sec-importance_of_k}
+#### Importance of $k$ {#sec-importance_of_k}
 
 The number of clusters $k$ is a hyperparameter we have to pick (some advanced algorithms can infer it automatically, but k-means is not one of them).
 
-![Example of k-means run on our toy data, with two different values of k. Setting k=4, on the left, results in one cluster being merged, compared to setting k=5, on the right. Which clustering do you think is better? How could you decide?](figures/effect_of_k.png){#fig-effect_of_k width="67%"}
+![Example of k-means run on our toy data, with two different values of $k$. Setting $k=4$, on the left, results in one cluster being merged, compared to setting $k=5$, on the right. Which clustering do you think is better? How could you decide?](figures/effect_of_k.png){#fig-effect_of_k width="67%"}
 
-@fig-effect_of_k shows an example of the effect. Which result looks more correct? It can be hard to say! Using higher k we get more clusters, and with more clusters we can achieve lower within-cluster variance -- the k-means objective will never increase, and will typically strictly decrease as we increase k. Eventually, we can increase k to equal the total number of datapoints, so that each datapoint is assigned to its own cluster. Then the k-means objective is zero, but the clustering reveals nothing. Clearly, then, we cannot use the k-means objective itself to choose the best value for k. In @sec-eval, we will discuss some ways of evaluating the success of clustering beyond its ability to minimize the k-means objective, and it's with these sorts of methods that we might decide on a proper value of k.
+@fig-effect_of_k shows an example of the effect. Which result looks more correct? It can be hard to say! Using higher $k$ we get more clusters, and with more clusters we can achieve lower within-cluster variance -- the k-means objective will never increase, and will typically strictly decrease as we increase $k$. Eventually, we can increase $k$ to equal the total number of datapoints, so that each datapoint is assigned to its own cluster. Then the k-means objective is zero, but the clustering reveals nothing. Clearly, then, we cannot use the k-means objective itself to choose the best value for $k$. In @sec-eval, we will discuss some ways of evaluating the success of clustering beyond its ability to minimize the k-means objective, and it's with these sorts of methods that we might decide on a proper value of $k$.
 
 :::{.column-margin}
-*Hierarchical clustering* sidesteps picking a single $k$ by producing a tree of clusterings at multiple granularities (coarse near the root, fine near the leaves), useful for discovering taxonomies (e.g., species, families, kingdoms). See SKLEARN's [cluster](https://scikit-learn.org/1.5/modules/clustering.html) module for many other clustering algorithms.
+*Hierarchical clustering* sidesteps picking a single $k$ by producing a tree of clusterings at multiple granularities (coarse near the root, fine near the leaves), useful for discovering taxonomies (e.g., species, families, kingdoms). See scikit-learn's [cluster](https://scikit-learn.org/1.5/modules/clustering.html) module for many other clustering algorithms.
 :::
 
 #### k-means in feature space
@@ -210,7 +214,7 @@ It suffices to search over partitions of the *training data* (not the whole inpu
 
 So we'll be greedy: pick the best single split by some criterion, then recurse. For now we pick the split that minimizes the total sum-of-squared-errors across the two children; we'll consider other criteria later.
 
-In the pseudocode below, `BuildTree` operates on a subset $I$ of the training indices (so the recursive calls work on the children of each split). For a candidate split at dimension $j$ and value $s$, we write $I^+_{j,s}$ and $I^-_{j,s}$ for the two children, and $\hat{y}^\pm_{j,s}$ for their average $y$ values. The hyperparameter $k$ is the largest leaf size we'll allow.
+In the pseudocode below, `BuildTree` operates on a subset $I$ of the training indices (so the recursive calls work on the children of each split). For a candidate split at dimension $j$ and value $s$, we write $I^+_{j,s}$ and $I^-_{j,s}$ for the two children, and $\hat{y}^\pm_{j,s}$ for their average $y$ values. The hyperparameter $n_{\min}$ is the largest leaf size we'll allow.
 
 
 ```pseudocode
@@ -224,10 +228,10 @@ In the pseudocode below, `BuildTree` operates on a subset $I$ of the training in
 #| label: buildtree
 \begin{algorithm}
 \begin{algorithmic}[1]
-\Procedure{BuildTree}{$I, k$}
-  \If{$|I| \leq k$}
+\Procedure{BuildTree}{$I, n_{\min}$}
+  \If{$|I| \leq n_{\min}$}
     \State $\hat{y} \gets \frac{1}{|I|}\sum_{i \in I} y^{(i)}$
-    \Return $\text{Leaf}(\text{value} = \hat{y})$
+    \State \Return $\text{Leaf}(\text{value} = \hat{y})$
   \Else
     \ForAll{split dimension $j$, split value $s$}
       \State $I^+_{j,s} \gets \{i \in I \mid x_j^{(i)} \geq s\}$
@@ -237,7 +241,7 @@ In the pseudocode below, `BuildTree` operates on a subset $I$ of the training in
       \State $E_{j,s} \gets \sum_{i \in I^+_{j,s}} (y^{(i)} - \hat{y}^+_{j,s})^2 \; + \; \sum_{i \in I^-_{j,s}} (y^{(i)} - \hat{y}^-_{j,s})^2$
     \EndFor
     \State $(j^*, s^*) \gets \arg\min_{j,s} E_{j,s}$
-    \State \Return $\text{Node}\bigl(j^*, s^*, \text{BuildTree}(I^-_{j^*,s^*}, k), \text{BuildTree}(I^+_{j^*,s^*}, k)\bigr)$
+    \State \Return $\text{Node}\bigl(j^*, s^*, \text{BuildTree}(I^-_{j^*,s^*}, n_{\min}), \text{BuildTree}(I^+_{j^*,s^*}, n_{\min})\bigr)$
   \EndIf
 \EndProcedure
 \end{algorithmic}
@@ -259,25 +263,24 @@ and the natural region error is the count of misclassified points:
 $$E_m = \bigl|\{i \in I_m \mid y^{(i)} \neq O_m\}\bigr|.$$
 We will also need the *empirical class probability* in region $m$:
 $$\hat{P}_{m,k} = \frac{\bigl|\{i \in I_m \mid y^{(i)} = k\}\bigr|}{N_m}, \qquad N_m = |I_m|.$$
-For splits, $\hat{P}_{m,j,s}$ denotes the fraction of points in region $m$ falling into one branch of the split $(j, s)$, and $1 - \hat{P}_{m,j,s}$ the other.
 
 #### Splitting criteria {#splitting-criteria}
 
 The greedy algorithm needs a way to decide which split to make next; we measure the "impurity" of a child node and pick the split that decreases impurity most. We use *entropy*:
-$$Q_m(T) = H(I_m) = -\sum_k \hat{P}_{m,k}\log_2 \hat{P}_{m,k},$$
+$$H(I_m) = -\sum_k \hat{P}_{m,k}\log_2 \hat{P}_{m,k},$$
 with the convention $0\log_2 0 = 0$ so $H$ is well-defined when $\hat{P} = 0$.
 
 :::{.callout-note collapse="true"}
 # Other impurity measures
-Two other common choices are *misclassification error* $1 - \hat{P}_{m,O_m}$ and the *Gini index* $\sum_k \hat{P}_{m,k}(1 - \hat{P}_{m,k})$. All three vanish on pure regions ($\hat{P}_{m,0} \in \{0, 1\}$) and peak near $\hat{P}_{m,0} = 0.5$, as the impurity curves below show (with $p = \hat{P}_{m,0}$). Tradition uses entropy when growing the tree and misclassification error when pruning.
+Two other common choices are *misclassification error* $1 - \hat{P}_{m,O_m}$ and the *Gini index* $\sum_k \hat{P}_{m,k}(1 - \hat{P}_{m,k})$. In the binary case (classes $0$ and $1$), all three vanish on pure regions ($\hat{P}_{m,0} \in \{0, 1\}$) and peak at $\hat{P}_{m,0} = 0.5$, as the impurity curves below show (with $p = \hat{P}_{m,0}$). Tradition uses entropy when growing the tree and misclassification error when pruning.
 
 ![](figures/impurity.png){width="60%" fig-align="center"}
 :::
 
 Analogous to regression (where we picked the split minimizing the sum of squared errors $E_{j,s}$), here we pick the split minimizing the weighted-average entropy of the two children:
 $$\hat{H} = \frac{|I^-_{j,s}|}{N_m}\, H(I^-_{j,s}) + \frac{|I^+_{j,s}|}{N_m}\, H(I^+_{j,s}).$$
-This is equivalent to maximizing the *information gain* of the test $x_j = s$:
-$$\text{infoGain}(x_j = s, I_m) = H(I_m) - \hat{H}.$$
+This is equivalent to maximizing the *information gain* of the test $x_j \geq s$:
+$$\text{infoGain}(x_j \geq s, I_m) = H(I_m) - \hat{H}.$$
 
 ### Pruning
 
@@ -285,7 +288,7 @@ Pruning applies to both regression and classification trees: in either case, nai
 
 We define the *cost complexity* of a tree $T$ (with leaves indexed by $m$) as
 $$C_\alpha(T) = \sum_{m=1}^{|T|} E_m(T) + \alpha |T|,$$
-where $|T|$ is the number of leaves and $E_m$ is whichever per-region error matches the task (sum of squared errors for regression, misclassification count for classification). For a fixed $\alpha$, "weakest-link" pruning approximately minimizes $C_\alpha(T)$:
+where $|T|$ is the number of leaves and $E_m$ is whichever per-region error matches the task (sum of squared errors for regression, misclassification count for classification). Here $\alpha$ plays the same role as $\lambda$ in the earlier regression objective ($\alpha$ is the traditional symbol for cost-complexity pruning). For a fixed $\alpha$, "weakest-link" pruning approximately minimizes $C_\alpha(T)$:
 
 -   Create a sequence of trees by successively removing the bottom-level split that minimizes the increase in overall error, until the root is reached.
 
@@ -297,9 +300,9 @@ We pick $\alpha$ by cross-validation.
 
 There are many variations on the tree theme. One is to employ different regression or classification methods in each leaf. For example, a linear regression might be used to model the examples in each leaf, rather than using a constant value.
 
-In the relatively simple trees that we've considered, splits have been based on only a single feature at a time, and with the resulting splits being axis-parallel. Other methods for splitting are possible, including consideration of multiple features and linear classifiers based on those, potentially resulting in non-axis-parallel splits. Complexity is a concern in such cases, as many possible combinations of features may need to be considered, to select the best variable combination (rather than a single split variable).
+In the relatively simple trees that we've considered, splits have been based on only a single feature at a time, so the resulting splits are axis-aligned. Other methods for splitting are possible, including consideration of multiple features and linear classifiers based on those, potentially resulting in non-axis-parallel splits. Complexity is a concern in such cases, as many possible combinations of features may need to be considered, to select the best variable combination (rather than a single split variable).
 
-Another generalization is a *hierarchical mixture of experts*, where we make a "soft" version of trees, in which the splits are probabilistic (so every point has some degree of membership in every leaf). Such trees can be trained using a form of gradient descent. Combinations of bagging, boosting, and mixture tree approaches (e.g., *gradient boosted trees*) and implementations are readily available (e.g., XGBoost).
+Another generalization is a *hierarchical mixture of experts*, where we make a "soft" version of trees, in which the splits are probabilistic (so every point has some degree of membership in every leaf). Such trees can be trained using a form of gradient descent. Combinations of bagging, boosting, and mixture-tree approaches (e.g., *gradient boosted trees*) are readily available in off-the-shelf implementations (e.g., XGBoost).
 
 Trees remain a valuable tool: they are interpretable, fast to train, handle multi-class targets and varied loss functions naturally, and expose feature importance. They also perform surprisingly well in practice; random forests and boosted trees are often used as a baseline against which to evaluate more sophisticated models.
 


### PR DESCRIPTION
Part of a chapter-by-chapter polish pass.

Non-parametric:
- infoGain now written with the threshold test x_j >= s (BuildTree splits on thresholds; the equality test was wrong for continuous features)
- Rename the max-leaf-size hyperparameter k -> n_min (k collided with the class index, k-NN, and k-means in the same chapter)
- Drop vestigial never-used symbols Q_m(T) and P_hat_{m,j,s}; note that alpha in cost-complexity pruning plays the same role as lambda earlier
- Margin note acknowledging the d (distance) vs d (dimension) reuse; metric codomain R^{>=0}
- k in math mode throughout the k-means discussion; scikit-learn naming; assorted phrasing

MDP:
- Fix reference to undefined V*_h (the object defined for policy evaluation is V^pi_h) and the off-by-one prose description of the Q recursion
- Balance parentheses in the two discounted-return displays
- Restore arrowheads in the wash-machine transition diagram (missing comma after -> in tikz options meant the arrow-tip style never applied)
- Upright Q/T/R per notation guide; gamma in [0,1) consistently; \lVert...\rVert_inf norms; linear-system paragraph now states the unique solution for gamma < 1
- Parenthesize bare cross-refs; heading level fix; assorted grammar

Verified: full `quarto render` passes.