### PR TITLE
Polish RL chapter and appendices

### DIFF
--- a/matrix_calculus.qmd
+++ b/matrix_calculus.qmd
@@ -5,7 +5,7 @@
 We all know how to calculate a derivative in single-variable calculus. If we have an input variable $x \in \mathbb{R}$ and a function $f(x): \mathbb{R} \rightarrow \mathbb{R}$, then:
 
 $$
-f'(x) = \frac{f(x + dx) - f(x)}{dx}
+f'(x) \approx \frac{f(x + dx) - f(x)}{dx}
 $$
 
 We generally define the numerator as $df = f(x + dx) - f(x)$, which gives $\frac{df}{dx}$ as our standard derivative. In other words, we can approximate some small change in the function as the derivative times a small change in our input variable:
@@ -51,7 +51,7 @@ $$\begin{aligned}
               \end{bmatrix}.
 \end{aligned}$$
 
--   Vector-by-scalar: For $x$ of size $1\times 1$ and ${\bf y}$ of size $m\times 1$, $\partial {\bf y}/\partial x$ is a row vector of size $1 \times m$ with the $j^{\rm th}$ entry $\partial {\bf y}_j/\partial x$:
+-   Vector-by-scalar: For $x$ of size $1\times 1$ and ${\bf y}$ of size $m\times 1$, $\partial {\bf y}/\partial x$ is a row vector of size $1 \times m$ with the $j^{\rm th}$ entry $\partial y_j/\partial x$:
 
 $$\begin{aligned}
 \partial {\bf y}/\partial x=
@@ -89,7 +89,7 @@ Additionally, notice that for all cases, you can explicitly compute each element
 
 ## Examples
 
-### Example 1 - Simple Numerical Example
+### Example 1: Simple Numerical Example
 
 Let us calculate the derivative of $f(\theta) = \theta_1^2 - 3\theta_2 + 5$. The input is a vector of size 2, and the output is a scalar. Therefore, our derivative $\frac{df}{d\theta}$ will be of size $(2 \times 1)$. More specifically, we know that:
 
@@ -133,7 +133,7 @@ $$
 
 Done!
 
-### Example 3: $f(v) = ||v||^2$
+### Example 3: $f(v) = \lVert v \rVert^2$
 
 Note that $f$ maps a column vector of size $n$ to a scalar. Therefore, the derivative $\frac{df}{dv}$ will be of size $(n \times 1)$. There are two ways to calculate this:
 
@@ -164,10 +164,10 @@ Let us use matrix calculus and the differential notation.
 $$
 \begin{align*}
 df &= f(v + dv) - f(v) \\
-   &= ||(v + dv)||^2 - ||v||^2 \\
-   &= (v + dv)^T(v + dv) - ||v||^2 \\
-   &= ||v||^2 + v^T dv + (dv)^T v + ||dv||^2 - ||v||^2 \\
-   &= (2v)^T dv + ||dv||^2
+   &= \lVert (v + dv) \rVert^2 - \lVert v \rVert^2 \\
+   &= (v + dv)^T(v + dv) - \lVert v \rVert^2 \\
+   &= \lVert v \rVert^2 + v^T dv + (dv)^T v + \lVert dv \rVert^2 - \lVert v \rVert^2 \\
+   &= (2v)^T dv + \lVert dv \rVert^2
 \end{align*}
 $$
 
@@ -191,7 +191,7 @@ $$
 \frac{df}{dv} = 2v
 $$
 
-### Example 4 - Chain Rule
+### Example 4: Chain Rule
 
 This is where the advantage of matrix calculus—and more specifically the denominator layout—really shines.
 
@@ -251,7 +251,7 @@ $$
 \frac{\partial {\bf x}}{\partial {\bf x}} = {\bf I}
 $$
 
-This is the $n \times n$ identity matrix, with 1's along the diagonal and 0's elsewhere. It makes sense, because $\partial {\bf x}_j / {\bf x}_i$ is 1 for $i = j$ and 0 otherwise. This identity is also similar to the scalar case.
+This is the $n \times n$ identity matrix, with 1's along the diagonal and 0's elsewhere. It makes sense, because $\partial x_j / \partial x_i$ is 1 for $i = j$ and 0 otherwise. This identity is also similar to the scalar case.
 
 ### Derivatives Involving a Constant Matrix
 
@@ -278,7 +278,7 @@ Therefore, the $(i,j)$ entry of $\frac{\partial {\bf A}{\bf x}}{\partial {\bf x}
 
 $$\frac{\partial {\bf A}{\bf x}}{\partial {\bf x}} = {\bf A}^T$${#eq-Ax}
 
-Similarly, for objects ${\bf x}, {\bf A}$ of the same shape, one can obtain,
+Similarly, for an $n \times 1$ vector ${\bf x}$ and an $n \times m$ matrix ${\bf A}$ that does not depend on ${\bf x}$, one can obtain,
 
 $$\frac{\partial {\bf x}^T {\bf A}}{\partial {\bf x}} = {\bf A}
 $${#eq-xTA}
@@ -360,7 +360,7 @@ $$
 
 ### Some Other Identities
 
-You can get many scalar-by-vector and vector-by-scalar cases as special cases of the rules above, making one of the relevant vectors just be 1 x 1. Here are some other ones that are handy. For more, see the Wikipedia article on Matrix derivatives (for consistency, only use the ones in *denominator layout*).
+You can get many scalar-by-vector and vector-by-scalar cases as special cases of the rules above, making one of the relevant vectors just be $1 \times 1$. Here are some other ones that are handy. For more, see the Wikipedia article on Matrix derivatives (for consistency, only use the ones in *denominator layout*).
 
 $$
 \frac{\partial {\bf u}^T {\bf v}}{\partial {\bf x}} = \frac{\partial
@@ -376,10 +376,10 @@ $${#eq-uT}
 From lecture/recitation, we know that the Mean Squared Error for Linear Regression can be written as:
 
 $$
-J(\theta) = \frac{1}{n} ||X\theta - Y||^2
+J(\theta) = \frac{1}{n} \lVert X\theta - Y \rVert^2
 $$
 
-where $X$ and $\theta$ are the augmented forms to allow for an intercept. Let us show how to optimize this function by setting its gradient equal to 0. We combine all of the facts that we learned. We know that the derivative of $||v||^2$ with respect to $v$ is $2v$, the derivative of $X\theta$ with respect to $\theta$ is $X^T$, and we know the chain rule. Combining all of that gives:
+where $X$ and $\theta$ are the augmented forms to allow for an intercept. Let us show how to optimize this function by setting its gradient equal to 0. We combine all of the facts that we learned. We know that the derivative of $\lVert v \rVert^2$ with respect to $v$ is $2v$, the derivative of $X\theta$ with respect to $\theta$ is $X^T$, and we know the chain rule. Combining all of that gives:
 
 $$
 \frac{dJ}{d\theta} = \frac{2}{n} X^T \cdot (X\theta - Y)
@@ -398,7 +398,7 @@ That's it! You can now derive the optimal solution for any linear regression pro
 In lecture, we also encountered the regularized MSE expression for Linear Regression:
 
 $$
-J(\theta) = \frac{1}{n} ||X\theta - Y||^2 + \lambda || \theta ||^2
+J(\theta) = \frac{1}{n} \lVert X\theta - Y \rVert^2 + \lambda \lVert \theta \rVert^2
 $$
 
 where $\lambda$ is some scalar hyperparameter we can choose.
@@ -440,7 +440,7 @@ $$\begin{aligned}
 \end{aligned}
 $$
 
-One neat way, which is very explicit, is to simply write all the matrices as variables with row and column indices, e.g., $X_{ab}$ is the row $a$, column $b$ entry of the matrix $X$. Furthermore, let us use the convention that in any product, all indices which appear more than once get summed over; this is a popular convention in theoretical physics, and lets us suppress all the summation symbols which would otherwise clutter the following expresssions. For example, $X_{ab} \theta_b$ would be the implicit summation notation giving the element at the $a^{\rm th}$ row of the matrix-vector product $X\theta$.
+One neat way, which is very explicit, is to simply write all the matrices as variables with row and column indices, e.g., $X_{ab}$ is the row $a$, column $b$ entry of the matrix $X$. Furthermore, let us use the convention that in any product, all indices which appear more than once get summed over; this is a popular convention in theoretical physics, and lets us suppress all the summation symbols which would otherwise clutter the following expressions. For example, $X_{ab} \theta_b$ would be the implicit summation notation giving the element at the $a^{\rm th}$ row of the matrix-vector product $X\theta$.
 
 Using implicit summation notation with explicit indices, we can rewrite $J(\theta)$ as
 
@@ -453,25 +453,25 @@ Note that we no longer need the transpose on the first term, because all that tr
 Taking the derivative of $J$ with respect to the $d^{\rm th}$ element of $\theta$ thus gives, using the chain rule for (ordinary scalar) multiplication:
 
 $$\begin{aligned}
-\frac{dJ}{d\theta_d} &=& \frac{1}{n} \left[
+\frac{dJ}{d\theta_d} &= \frac{1}{n} \left[
   X_{ab} \delta_{bd} \left( X_{ac}\theta_c-Y_a \right)
   + \left(X_{ab}\theta_b - Y_a \right) X_{ac} \delta_{cd}
   \right]
 \\
-&=& \frac{1}{n} \left[
+&= \frac{1}{n} \left[
   X_{ad} \left( X_{ac}\theta_c-Y_a \right)
   + \left(X_{ab}\theta_b - Y_a \right) X_{ad}
   \right]
 \\
-&=& \frac{2}{n} X_{ad} \left( X_{ab}\theta_b-Y_a \right)
+&= \frac{2}{n} X_{ad} \left( X_{ab}\theta_b-Y_a \right)
 \,,
 \end{aligned}$$
-where the second line follows from the first, with the definition that $\delta_{bd} = 1$ only when $b=d$ (and similarly for $\delta_{cd}$). And the third line follows from the second by recognizing that the two terms in the second line are identical. Now note that in this implicit summation notation, the $a, b$ element of the matrix product of $A$ and $B$ is $(AB)_{ac} = A_{ab}B_{bc}$. That is, ordinary matrix multiplication sums over indices which are adjacent to each other, because a row of $A$ times a column of $B$ becomes a scalar number. So the term in the above equation with $X_{ad} X_{ab}$ is not a matrix product of $X$ with $X$. However, taking the transpose $X^T$ switches row and column indices, so $X_{ad} = X^T_{da}$. And $X^T_{da} X_{ab}$ *is* a matrix product of $X^T$ with $X$! Thus, we have that
+where the second line follows from the first, with the definition that $\delta_{bd} = 1$ only when $b=d$ (and similarly for $\delta_{cd}$). And the third line follows from the second by recognizing that the two terms in the second line are identical. Now note that in this implicit summation notation, the $a, c$ element of the matrix product of $A$ and $B$ is $(AB)_{ac} = A_{ab}B_{bc}$. That is, ordinary matrix multiplication sums over indices which are adjacent to each other, because a row of $A$ times a column of $B$ becomes a scalar number. So the term in the above equation with $X_{ad} X_{ab}$ is not a matrix product of $X$ with $X$. However, taking the transpose $X^T$ switches row and column indices, so $X_{ad} = X^T_{da}$. And $X^T_{da} X_{ab}$ *is* a matrix product of $X^T$ with $X$! Thus, we have that
 
 $$\begin{aligned}
-\frac{dJ}{d\theta_d} =& \frac{2}{n} X^T_{da} \left( X_{ab}\theta_b-Y_a \right)
+\frac{dJ}{d\theta_d} &= \frac{2}{n} X^T_{da} \left( X_{ab}\theta_b-Y_a \right)
 \\
-=& \frac{2}{n} \left[ X^T \left( X\theta-Y\right) \right]_{d}
+&= \frac{2}{n} \left[ X^T \left( X\theta-Y\right) \right]_{d}
 \,,
 \end{aligned}
 $$ which is the desired result.

--- a/neural_network_appendix.qmd
+++ b/neural_network_appendix.qmd
@@ -60,7 +60,7 @@ Prove to yourself that these formulations are equivalent.
 We will find that $V_t$ will be bigger in dimensions that consistently have the same sign for $\nabla_W$ and smaller for those that don't. Of course we now have *two* parameters to set ($\eta$ and $\gamma$), but the hope is that the algorithm will perform better overall, so it will be worth trying to find good values for them. Often $\gamma$ is set to be something like $0.9$.
 
 ::: {.example}
-![Momentum](figures/momentum.png){scale=0.7}
+![Momentum](figures/momentum.png){width=70%}
 
 The red arrows show the update after each successive step of mini-batch gradient descent with momentum. The blue points show the direction of the gradient with respect to the mini-batch at each step. Momentum smooths the path taken towards the local minimum and leads to faster convergence.
 :::
@@ -83,6 +83,10 @@ $$
 
 The sequence $G_{t,j}$ is a moving average of the square of the $j$th component of the gradient. We square it in order to be insensitive to the sign—we want to know whether the magnitude is big or small. Then, we perform a gradient update to weight $j$, but divide the step size by $\sqrt{G_{t,j}+\epsilon}$, which is larger when the surface is steeper in direction $j$ at point $W_{t-1}$ in weight space; this means that the step size will be smaller when it's steep and larger when it's flat.
 
+::: {.column-margin}
+The variant shown here, with a fixed $\eta$, is usually called *RMSProp*; full adadelta additionally replaces $\eta$ with a running RMS of past parameter updates.
+:::
+
 ### Adam
 
 Adam has become the default method of managing step sizes in neural networks.
@@ -96,8 +100,8 @@ It combines the ideas of momentum and adadelta. We start by writing moving avera
 $$
 \begin{aligned}
   g_{t,j} &= \nabla_W J(W_{t-1})_j, \\
-  m_{t,j} &= B_1\, m_{t-1,j} + (1-B_1)\, g_{t,j}, \\
-  v_{t,j} &= B_2\, v_{t-1,j} + (1-B_2)\, g_{t,j}^2.
+  m_{t,j} &= \beta_1\, m_{t-1,j} + (1-\beta_1)\, g_{t,j}, \\
+  v_{t,j} &= \beta_2\, v_{t-1,j} + (1-\beta_2)\, g_{t,j}^2.
 \end{aligned}
 $$
 
@@ -105,19 +109,19 @@ A problem with these estimates is that, if we initialize $m_0 = v_0 = 0$, they w
 
 $$
 \begin{aligned}
-  \hat{m}_{t,j} &= \frac{m_{t,j}}{1-B_1^t}, \\
-  \hat{v}_{t,j} &= \frac{v_{t,j}}{1-B_2^t}, \\
+  \hat{m}_{t,j} &= \frac{m_{t,j}}{1-\beta_1^t}, \\
+  \hat{v}_{t,j} &= \frac{v_{t,j}}{1-\beta_2^t}, \\
   W_{t,j} &= W_{t-1,j} - \frac{\eta}{\sqrt{\hat{v}_{t,j}+\epsilon}}\, \hat{m}_{t,j}.
 \end{aligned}
 $$
 
-Note that $B_1^t$ is $B_1$ raised to the power $t$, and likewise for $B_2^t$. To justify these corrections, note that if we were to expand $m_{t,j}$ in terms of $m_{0,j}$ and $g_{0,j}, g_{1,j}, \dots, g_{t,j}$, the coefficients would sum to 1. However, the coefficient behind $m_{0,j}$ is $B_1^t$ and since $m_{0,j} = 0$, the sum of coefficients of nonzero terms is $1-B_1^t$; hence the correction. The same justification holds for $v_{t,j}$.
+Note that $\beta_1^t$ is $\beta_1$ raised to the power $t$, and likewise for $\beta_2^t$. To justify these corrections, note that if we were to expand $m_{t,j}$ in terms of $m_{0,j}$ and $g_{0,j}, g_{1,j}, \dots, g_{t,j}$, the coefficients would sum to 1. However, the coefficient on $m_{0,j}$ is $\beta_1^t$ and since $m_{0,j} = 0$, the sum of coefficients of nonzero terms is $1-\beta_1^t$; hence the correction. The same justification holds for $v_{t,j}$.
 
 :::{.study-question-callout}
 Define $\hat{m}_{t,j}$ directly as a moving average of $g_{t,j}$. What is the decay ($\gamma$ parameter)?
 :::
 
-Even though we now have a step size for each weight, and we have to update various quantities on each iteration of gradient descent, it's relatively easy to implement by maintaining a matrix for each quantity ($m^{\ell}_t$, $v^{\ell}_t$, $g^{\ell}_t$, ${g^{2}_t}^{\ell}$) in each layer of the network.
+Even though we now have a step size for each weight, and we have to update various quantities on each iteration of gradient descent, it's relatively easy to implement by maintaining a matrix for each quantity ($m^l_t$, $v^l_t$, $g^l_t$, $(g^l_t)^2$) in each layer of the network.
 
 ## Batch Normalization Details {#sec-batch-norm-appendix}
 
@@ -151,39 +155,39 @@ $$
 
 That's the forward pass. Whew!
 
-Now, for the backward pass, we have to do two things: given $\frac{\partial L}{\partial \widehat{Z}^l}$,
+Now, for the backward pass, we have to do two things: given $\frac{\partial \mathcal{L}}{\partial \widehat{Z}^l}$,
 
-- Compute $\frac{\partial L}{\partial Z^l}$ for back-propagation, and  
-- Compute $\frac{\partial L}{\partial G^l}$ and $\frac{\partial L}{\partial B^l}$ for gradient updates of the weights in this layer.
+- Compute $\frac{\partial \mathcal{L}}{\partial Z^l}$ for back-propagation, and  
+- Compute $\frac{\partial \mathcal{L}}{\partial G^l}$ and $\frac{\partial \mathcal{L}}{\partial B^l}$ for gradient updates of the weights in this layer.
 
 Schematically, we have
 
 $$
-\frac{\partial L}{\partial B} = \frac{\partial L}{\partial \widehat{Z}}\, \frac{\partial \widehat{Z}}{\partial B}.
+\frac{\partial \mathcal{L}}{\partial B} = \frac{\partial \mathcal{L}}{\partial \widehat{Z}}\, \frac{\partial \widehat{Z}}{\partial B}.
 $$
 
 It's hard to think about these derivatives in matrix terms, so we'll see how it works for the components. $B_i$ contributes to $\widehat{Z}_{ij}$ for all data points $j$ in the batch. So,
 
 $$
-\frac{\partial L}{\partial B_i} = \sum_j \frac{\partial L}{\partial \widehat{Z}_{ij}}\, \frac{\partial \widehat{Z}_{ij}}{\partial B_i} = \sum_j \frac{\partial L}{\partial \widehat{Z}_{ij}}.
+\frac{\partial \mathcal{L}}{\partial B_i} = \sum_j \frac{\partial \mathcal{L}}{\partial \widehat{Z}_{ij}}\, \frac{\partial \widehat{Z}_{ij}}{\partial B_i} = \sum_j \frac{\partial \mathcal{L}}{\partial \widehat{Z}_{ij}}.
 $$
 
 Similarly, $G_i$ contributes to $\widehat{Z}_{ij}$ for all data points $j$ in the batch. Thus,
 
 $$
-\frac{\partial L}{\partial G_i} = \sum_j \frac{\partial L}{\partial \widehat{Z}_{ij}}\, \frac{\partial \widehat{Z}_{ij}}{\partial G_i} = \sum_j \frac{\partial L}{\partial \widehat{Z}_{ij}}\, \overline{Z}_{ij}.
+\frac{\partial \mathcal{L}}{\partial G_i} = \sum_j \frac{\partial \mathcal{L}}{\partial \widehat{Z}_{ij}}\, \frac{\partial \widehat{Z}_{ij}}{\partial G_i} = \sum_j \frac{\partial \mathcal{L}}{\partial \widehat{Z}_{ij}}\, \overline{Z}_{ij}.
 $$
 
 Now, let's figure out how to do backprop. We can start schematically:
 
 $$
-\frac{\partial L}{\partial Z} = \frac{\partial L}{\partial \widehat{Z}}\, \frac{\partial \widehat{Z}}{\partial Z}.
+\frac{\partial \mathcal{L}}{\partial Z} = \frac{\partial \mathcal{L}}{\partial \widehat{Z}}\, \frac{\partial \widehat{Z}}{\partial Z}.
 $$
 
 And because dependencies only exist across the batch, but not across the unit outputs,
 
 $$
-\frac{\partial L}{\partial Z_{ij}} = \sum_{k=1}^K \frac{\partial L}{\partial \widehat{Z}_{ik}}\, \frac{\partial \widehat{Z}_{ik}}{\partial Z_{ij}}.
+\frac{\partial \mathcal{L}}{\partial Z_{ij}} = \sum_{k=1}^K \frac{\partial \mathcal{L}}{\partial \widehat{Z}_{ik}}\, \frac{\partial \widehat{Z}_{ik}}{\partial Z_{ij}}.
 $$
 
 The next step is to note that
@@ -192,7 +196,7 @@ $$
 \frac{\partial \widehat{Z}_{ik}}{\partial Z_{ij}} = \frac{\partial \widehat{Z}_{ik}}{\partial \overline{Z}_{ik}}\, \frac{\partial \overline{Z}_{ik}}{\partial Z_{ij}} = G_i\, \frac{\partial \overline{Z}_{ik}}{\partial Z_{ij}}.
 $$
 
-And now that
+And now, note that
 
 $$
 \frac{\partial \overline{Z}_{ik}}{\partial Z_{ij}} = \Bigl(\delta_{jk} - \frac{\partial \mu_i}{\partial Z_{ij}}\Bigr)\frac{1}{\sigma_i} - \frac{Z_{ik}-\mu_i}{\sigma_i^2}\, \frac{\partial \sigma_i}{\partial Z_{ij}},
@@ -208,5 +212,5 @@ $$
 Putting the whole thing together, we get
 
 $$
-\frac{\partial L}{\partial Z_{ij}} = \sum_{k=1}^K \frac{\partial L}{\partial \widehat{Z}_{ik}}\, G_i\, \frac{1}{K\,\sigma_i}\left(K\,\delta_{jk} - 1 - \frac{(Z_{ik}-\mu_i)(Z_{ij}-\mu_i)}{\sigma_i^2}\right).
+\frac{\partial \mathcal{L}}{\partial Z_{ij}} = \sum_{k=1}^K \frac{\partial \mathcal{L}}{\partial \widehat{Z}_{ik}}\, G_i\, \frac{1}{K\,\sigma_i}\left(K\,\delta_{jk} - 1 - \frac{(Z_{ik}-\mu_i)(Z_{ij}-\mu_i)}{\sigma_i^2}\right).
 $$

--- a/nutshell.qmd
+++ b/nutshell.qmd
@@ -9,24 +9,26 @@ We start with a very generic setting.
 ### Minimal problem specification
 
 Given:
-- Space of inputs \(X\)
-- Space of outputs \(y\)
-- Space of possible hypotheses \(\mathcal{H}\) such that each \(h \in \mathcal{H}\) is a function \(h: x \rightarrow y\)
-- Loss function \(\mathcal{L}: y \times y \rightarrow \mathbb{R}\)
-a supervised learning algorithm \(\mathcal{A}\) takes as input a data set of the form
+
+- Space of inputs $\mathcal{X}$
+- Space of outputs $\mathcal{Y}$
+- Space of possible hypotheses $\mathcal{H}$ such that each $h \in \mathcal{H}$ is a function $h: \mathcal{X} \rightarrow \mathcal{Y}$
+- Loss function $\mathcal{L}: \mathcal{Y} \times \mathcal{Y} \rightarrow \mathbb{R}$
+
+a supervised learning algorithm $\mathcal{A}$ takes as input a data set of the form
 
 $$
 \mathcal{D}=\left\{\left(x^{(1)}, y^{(1)}\right), \ldots,\left(x^{(n)}, y^{(n)}\right)\right\}
 $$
 
-where $x^{(i)} \in X$ and $y^{(i)} \in y$ and returns an $h \in \mathcal{H}$.
+where $x^{(i)} \in \mathcal{X}$ and $y^{(i)} \in \mathcal{Y}$ and returns an $h \in \mathcal{H}$.
 
 
 ### Evaluating a hypothesis
 
 Given a problem specification and a set of data $\mathcal{D}$, we evaluate hypothesis $h$ according to average loss, or error,
 $$
-\mathcal{E}(h, \mathcal{L}, \mathcal{D})=\frac{1}{|\mathcal{D}|} \sum_{i=1}^{\mathcal{D}} \mathcal{L}\left(h\left(x^{(i)}\right), y^{(i)}\right)
+\mathcal{E}(h, \mathcal{L}, \mathcal{D})=\frac{1}{|\mathcal{D}|} \sum_{i=1}^{|\mathcal{D}|} \mathcal{L}\left(h\left(x^{(i)}\right), y^{(i)}\right)
 $$
 
 
@@ -38,22 +40,22 @@ A *validation strategy* $\mathcal{V}$ takes an algorithm $\mathcal{A}$, a loss f
 
 #### Using a validation set
 
-In the simplest case, we can divide $\mathcal{D}$ into two sets, $\mathcal{D}^{\text {train }}$ and $\mathcal{D}^{\text {val }}$, train on the first, and then evaluate the resulting hypothesis on the second. In that case,
+In the simplest case, we can divide $\mathcal{D}$ into two sets, $\mathcal{D}^{\text{train}}$ and $\mathcal{D}^{\text{val}}$, train on the first, and then evaluate the resulting hypothesis on the second. In that case,
 
 $$
-\mathcal{V}(\mathcal{A}, \mathcal{L}, \mathcal{D})=\mathcal{E}\left(\mathcal{A}\left(\mathcal{D}^{\text {train }}\right), \mathcal{L}, \mathcal{D}^{\text {val }}\right)
+\mathcal{V}(\mathcal{A}, \mathcal{L}, \mathcal{D})=\mathcal{E}\left(\mathcal{A}\left(\mathcal{D}^{\text{train}}\right), \mathcal{L}, \mathcal{D}^{\text{val}}\right)
 $$
 
 #### Using multiple training/evaluation runs
 
 We can't reliably evaluate an algorithm based on a single application to a single training and test set, because there are many aspects of the training and testing data, as well as, sometimes, randomness in the algorithm itself, that cause *variance* in the performance of the algorithm. To get a good idea of how well an algorithm performs, we need to, multiple times, train it and evaluate the resulting hypothesis, and report the average over $K$ executions of the algorithm of the error of the hypothesis it produced each time.
 
-We divide the data into 2 K random non-overlapping subsets: $\mathcal{D}_1^{\text {train }}, \mathcal{D}_1^{\text {val }}, \ldots, \mathcal{D}_{\mathrm{K}}^{\text {train }}, \mathcal{D}_{\mathrm{K}}^{\text {val }}$.
+We divide the data into 2 K random non-overlapping subsets: $\mathcal{D}_1^{\text{train}}, \mathcal{D}_1^{\text{val}}, \ldots, \mathcal{D}_{\mathrm{K}}^{\text{train}}, \mathcal{D}_{\mathrm{K}}^{\text{val}}$.
 
 Then,
 
 $$
-\mathcal{V}(\mathcal{A}, \mathcal{L}, \cal D) = \frac{1}{K}\sum_{k=1}^K \mathcal{E}\Bigl(\mathcal{A}\bigl(\cal D_k^\text{train}\bigr), \mathcal{L}, \cal D_k^\text{val}\Bigr)\;.
+\mathcal{V}(\mathcal{A}, \mathcal{L}, \mathcal{D}) = \frac{1}{K}\sum_{k=1}^K \mathcal{E}\Bigl(\mathcal{A}\bigl(\mathcal{D}_k^\text{train}\bigr), \mathcal{L}, \mathcal{D}_k^\text{val}\Bigr)\;.
 $$
 
 #### Cross validation
@@ -62,9 +64,9 @@ In *cross validation*, we do a similar computation, but allow data to be re-used
 
 ### Comparing supervised learning algorithms
 
-Now, if we have two different algorithms $\mathcal{A}_1$ and $\mathcal{A}_2$, we might be interested in knowing which one will produce hypotheses that generalize the best, using data from a particular source. We could compute $\mathcal{V}\left(\mathcal{A}_1, \mathcal{L}, \mathcal{D}\right)$ and $\mathcal{V}\left(\mathcal{A}_{\in}, \mathcal{L}, \mathcal{D}\right)$, and prefer the algorithm with lower validation error. More generally, given algorithms $\mathcal{A}_1, \ldots, \mathcal{A}_M$, we would prefer
+Now, if we have two different algorithms $\mathcal{A}_1$ and $\mathcal{A}_2$, we might be interested in knowing which one will produce hypotheses that generalize the best, using data from a particular source. We could compute $\mathcal{V}\left(\mathcal{A}_1, \mathcal{L}, \mathcal{D}\right)$ and $\mathcal{V}\left(\mathcal{A}_{2}, \mathcal{L}, \mathcal{D}\right)$, and prefer the algorithm with lower validation error. More generally, given algorithms $\mathcal{A}_1, \ldots, \mathcal{A}_M$, we would prefer
 $$
-\mathcal{A}^*=\arg \min _{\mathrm{m}} \mathcal{V}\left(\mathcal{A}_M, \mathcal{L}, \mathcal{D}\right)
+\mathcal{A}^*=\arg\min_{m} \mathcal{V}\left(\mathcal{A}_m, \mathcal{L}, \mathcal{D}\right)
 $$
 
 
@@ -73,7 +75,7 @@ $$
 Now what? We have to deliver a hypothesis to our customer. We now know how to find the algorithm, $\mathcal{A}^*$, that works best for our type of data. We can apply it to all of our data to get the best hypothesis we know how to create, which would be
 
 $$
-\mathrm{h}^*=\mathcal{A}^*(\mathcal{D})
+h^*=\mathcal{A}^*(\mathcal{D})
 $$
 
 and deliver this resulting hypothesis as our best product.
@@ -89,7 +91,7 @@ Interestingly, this loss function is *not always the same* as the loss function 
 So for example, (assuming a perfect optimizer which doesn't, of course, exist) we might say our algorithm is to solve an optimization problem:
 
 $$
-\mathcal{A}(\mathcal{D})=\arg \min _{h \in H} \mathcal{J}(h ; \mathcal{D}) .
+\mathcal{A}(\mathcal{D})=\arg\min_{h \in \mathcal{H}} \mathcal{J}(h ; \mathcal{D}) .
 $$
 
 Our objective often has the form
@@ -113,36 +115,31 @@ Then we could think of our algorithm as $\mathcal{A}(\mathcal{D} ; \lambda)$. Pi
 
 In linear regression the problem formulation is this:
 
-- $x=\mathbb{R}^{\mathrm{d}}$
-- $y=\mathbb{R}$
-- $\mathcal{H}=\left\{\theta^{\top} x+\theta_0\right\}$ for values of parameters $\theta \in \mathbb{R}^d$ and $\theta_0 \in \mathbb{R}$.
+- $\mathcal{X}=\mathbb{R}^d$
+- $\mathcal{Y}=\mathbb{R}$
+- $\mathcal{H}=\left\{\theta^T x+\theta_0\right\}$ for values of parameters $\theta \in \mathbb{R}^d$ and $\theta_0 \in \mathbb{R}$.
 - $\mathcal{L}(g, y)=(g-y)^2$
 
 Our learning algorithm has hyperparameter $\lambda$ and can be written as:
 
 $$
-\mathcal{A}(\mathcal{D} ; \lambda)=\Theta^*(\lambda, \mathcal{D})=\arg \min _{\theta, \theta_0} \frac{1}{|\mathcal{D}|} \sum_{(x, y) \in \mathcal{D}}\left(\theta^{\top} x+\theta_0-y\right)^2+\lambda\|\theta\|^2
+\mathcal{A}(\mathcal{D} ; \lambda)=\Theta^*(\lambda, \mathcal{D})=\arg \min _{\theta, \theta_0} \frac{1}{|\mathcal{D}|} \sum_{(x, y) \in \mathcal{D}}\left(\theta^T x+\theta_0-y\right)^2+\lambda\|\theta\|^2
 $$
 
-
-Our learning algorithm has hyperparameter $ \lambda $ and can be written as:
-$$
-\mathcal{A}(\mathcal{D} ; \lambda)=\Theta^*(\lambda, \mathcal{D})=\arg \min _{\theta, \theta_0} \frac{1}{|\mathcal{D}|} \sum_{(x, y) \in \mathcal{D}}\left(\theta^{\top} x+\theta_0-y\right)^2+\lambda\|\theta\|^2 .
-$$
 
 For a particular training data set and parameter $\lambda$, it finds the best hypothesis on this data, specified with parameters $\Theta=\left(\theta, \theta_0\right)$, written $\Theta^*(\lambda, \mathcal{D})$.
 
-Picking the best value of the hyperparameter is choosing among learning algorithms. We could, most simply, optimize using a single training / validation split, so $\mathcal{D}=\mathcal{D}^{\text {train }} \cup$ $\mathcal{D}^{\text {val }}$, and
+Picking the best value of the hyperparameter is choosing among learning algorithms. We could, most simply, optimize using a single training / validation split, so $\mathcal{D}=\mathcal{D}^{\text{train}} \cup$ $\mathcal{D}^{\text{val}}$, and
 
 $$
 \begin{aligned}
-\lambda^* & =\arg \min _\lambda \mathcal{V}\left(\mathcal{A}_\lambda, \mathcal{L}, \mathcal{D}^{\text {val }}\right) \\
-& =\arg \min _\lambda \mathcal{E}\left(\Theta^*\left(\lambda, \mathcal{D}^{\text {train }}\right), \text { mse, } \mathcal{D}^{\text {val }}\right) \\
-& =\arg \min _\lambda \frac{1}{\left|\mathcal{D}_{\text {val }}\right|} \sum_{(x, y) \in \mathcal{D}_{\text {val }}}\left(\theta^*\left(\lambda, \mathcal{D}^{\text {train }}\right)^{\top} x+\theta_0^*\left(\lambda, \mathcal{D}^{\text {train }}\right)-y\right)^2
+\lambda^* & =\arg \min _\lambda \mathcal{V}\left(\mathcal{A}_\lambda, \mathcal{L}, \mathcal{D}\right) \\
+& =\arg \min _\lambda \mathcal{E}\left(\Theta^*\left(\lambda, \mathcal{D}^{\text{train}}\right), \text{mse}, \mathcal{D}^{\text{val}}\right) \\
+& =\arg \min _\lambda \frac{1}{\left|\mathcal{D}^{\text{val}}\right|} \sum_{(x, y) \in \mathcal{D}^{\text{val}}}\left(\theta^*\left(\lambda, \mathcal{D}^{\text{train}}\right)^T x+\theta_0^*\left(\lambda, \mathcal{D}^{\text{train}}\right)-y\right)^2
 \end{aligned}
 $$
 
-It would be much better to select the best $\lambda$ using multiple runs or cross-validation; that would just be a different choices of the validation procedure $\mathcal{V}$ in the top line.
+It would be much better to select the best $\lambda$ using multiple runs or cross-validation; that would just be a different choice of the validation procedure $\mathcal{V}$ in the top line.
 
 Note that we don't use regularization here because we just want to measure how good the output of the algorithm is at predicting values of *new* points, and so that's what we measure. We use the regularizer during training when we don't want to focus only on optimizing predictions on the training data.
 
@@ -151,7 +148,7 @@ $$
 \begin{aligned}
 \Theta^* & =\mathcal{A}\left(\mathcal{D} ; \lambda^*\right) \\
 & =\Theta^*\left(\lambda^*, \mathcal{D}\right) \\
-& =\arg \min _{\theta, \theta_0} \frac{1}{|\mathcal{D}|} \sum_{(x, y) \in \mathcal{D}}\left(\theta^{\top} x+\theta_0-y\right)^2+\lambda^*\|\theta\|^2
+& =\arg \min _{\theta, \theta_0} \frac{1}{|\mathcal{D}|} \sum_{(x, y) \in \mathcal{D}}\left(\theta^T x+\theta_0-y\right)^2+\lambda^*\|\theta\|^2
 \end{aligned}
 $$
 
@@ -160,8 +157,8 @@ Finally, a customer might evaluate this hypothesis on their data, which we have 
 
 $$
 \begin{aligned}
-\mathcal{E}^{\text {test }} & =\mathcal{E}\left(\Theta^*, \text { mse }, \mathcal{D}^{\text {test }}\right) \\
-& =\frac{1}{\left|\mathcal{D}^{\text {test }}\right|} \sum_{(x, y) \in \mathcal{D}^{\text {tot }}}\left(\theta^{* T} x+\theta_0^*-y\right)^2
+\mathcal{E}^{\text{test}} & =\mathcal{E}\left(\Theta^*, \text{mse}, \mathcal{D}^{\text{test}}\right) \\
+& =\frac{1}{\left|\mathcal{D}^{\text{test}}\right|} \sum_{(x, y) \in \mathcal{D}^{\text{test}}}\left(\theta^{* T} x+\theta_0^*-y\right)^2
 \end{aligned}
 $$
 
@@ -175,7 +172,7 @@ define train(D, lambda):
 # returns lambda_best using very simple validation
 define simple_tune(D_train, D_val, possible_lambda_vals):
     scores = [mse(train(D_train, lambda), D_val) for lambda in possible_lambda_vals]
-    return possible_lambda_vals[least_index[scores]]
+    return possible_lambda_vals[least_index(scores)]
 
 # returns theta_best overall
 define theta_best(D_train, D_val, possible_lambda_vals):
@@ -190,34 +187,35 @@ define customer_val(theta):
 
 In binary logistic regression the problem formulation is as follows. We are writing the class labels as 1 and 0.
 
-- $\mathcal{X} = \mathbb{R}^d$
-- $y=\{+1,0\}$
-- $\mathcal{H}=\left\{\sigma\left(\theta^{\top} x+\theta_0\right)\right\}$ for values of parameters $\theta \in \mathbb{R}^d$ and $\theta_0 \in \mathbb{R}$.
-- $\mathcal{L}(\mathrm{g}, \mathrm{y})=\mathcal{L}_{01}(\mathrm{~g}, \mathrm{~h})$
+- $\mathcal{X}=\mathbb{R}^d$
+- $\mathcal{Y}=\{+1,0\}$
+- $\mathcal{H}=\left\{\sigma\left(\theta^T x+\theta_0\right)\right\}$ for values of parameters $\theta \in \mathbb{R}^d$ and $\theta_0 \in \mathbb{R}$.
+- $\mathcal{L}(g, y)=\mathcal{L}_{01}(g, y)$
 - Proxy loss $\mathcal{L}_{\mathrm{nll}}(\mathrm{g}, \mathrm{y})=-(\mathrm{y} \log (g)+(1-y) \log (1-g))$
+
 Our learning algorithm has hyperparameter $\lambda$ and can be written as:
 
 $$
-\mathcal{A}(\mathcal{D} ; \lambda)=\Theta^*(\lambda, \mathcal{D})=\arg \min _{\theta, \theta_0} \frac{1}{|\mathcal{D}|} \sum_{(x, y) \in \mathcal{D}} \mathcal{L}_{\mathrm{nll}}\left(\sigma\left(\theta^{\top} x+\theta_0\right), y\right)+\lambda\|\theta\|^2
+\mathcal{A}(\mathcal{D} ; \lambda)=\Theta^*(\lambda, \mathcal{D})=\arg \min _{\theta, \theta_0} \frac{1}{|\mathcal{D}|} \sum_{(x, y) \in \mathcal{D}} \mathcal{L}_{\mathrm{nll}}\left(\sigma\left(\theta^T x+\theta_0\right), y\right)+\lambda\|\theta\|^2
 $$
 
-For a particular training data set and parameter $\lambda$, it finds the best hypothesis on this data, specified with parameters $\Theta=\left(\theta, \theta_0\right)$, written $\Theta^*(\lambda, \mathcal{D})$ according to the proxy loss $\mathcal{L}_{\text {nll }}$.
+For a particular training data set and parameter $\lambda$, it finds the best hypothesis on this data, specified with parameters $\Theta=\left(\theta, \theta_0\right)$, written $\Theta^*(\lambda, \mathcal{D})$ according to the proxy loss $\mathcal{L}_{\text{nll}}$.
 
-Picking the best value of the hyperparameter is choosing among learning algorithms based on their actual predictions. We could, most simply, optimize using a single training / validation split, so $\mathcal{D}=\mathcal{D}^{\text {train }} \cup \mathcal{D}^{\mathrm{val}}$, and we use the real 01 loss:
+Picking the best value of the hyperparameter is choosing among learning algorithms based on their actual predictions. We could, most simply, optimize using a single training / validation split, so $\mathcal{D}=\mathcal{D}^{\text{train}} \cup \mathcal{D}^{\mathrm{val}}$, and we use the real 01 loss (where the classifier predicts $1$ when $\sigma(\cdot) > 0.5$ and $0$ otherwise):
 
 $$
 \begin{aligned}
-\lambda^* & =\arg \min _\lambda \mathcal{V}\left(\mathcal{A}_\lambda, \mathcal{L}_{01}, \mathcal{D}^{\text {val }}\right) \\
-& =\arg \min _\lambda \mathcal{E}\left(\Theta^*\left(\lambda, \mathcal{D}^{\text {train }}\right), \mathcal{L}_{01}, \mathcal{D}^{\text {val }}\right) \\
-& =\arg \min _\lambda \frac{1}{\left|\mathcal{D}_{\text {val }}\right|} \sum_{(x, y) \in \mathcal{D}_{\text {val }}} \mathcal{L}_{01}\left(\sigma\left(\theta^*\left(\lambda, \mathcal{D}^{\text {train }}\right)^{\top} x+\theta_0^*\left(\lambda, \mathcal{D}^{\text {train }}\right)\right), y\right)
+\lambda^* & =\arg \min _\lambda \mathcal{V}\left(\mathcal{A}_\lambda, \mathcal{L}_{01}, \mathcal{D}\right) \\
+& =\arg \min _\lambda \mathcal{E}\left(\Theta^*\left(\lambda, \mathcal{D}^{\text{train}}\right), \mathcal{L}_{01}, \mathcal{D}^{\text{val}}\right) \\
+& =\arg \min _\lambda \frac{1}{\left|\mathcal{D}^{\text{val}}\right|} \sum_{(x, y) \in \mathcal{D}^{\text{val}}} \mathcal{L}_{01}\left(\sigma\left(\theta^*\left(\lambda, \mathcal{D}^{\text{train}}\right)^T x+\theta_0^*\left(\lambda, \mathcal{D}^{\text{train}}\right)\right), y\right)
 \end{aligned}
 $$
 
-It would be much better to select the best $\lambda$ using multiple runs or cross-validation; that would just be a different choices of the validation procedure $\mathcal{V}$ in the top line.
+It would be much better to select the best $\lambda$ using multiple runs or cross-validation; that would just be a different choice of the validation procedure $\mathcal{V}$ in the top line.
 
 Finally! To make a predictor to ship out into the world, we would use all the data we have, $\mathcal{D}$, to train, using the best hyperparameters we know, and return
 $$
-\Theta^* = \mathcal{A}(\cal D; \lambda^*)
+\Theta^* = \mathcal{A}(\mathcal{D}; \lambda^*)
 $$
 
 :::{.study-question-callout}
@@ -227,7 +225,7 @@ What loss function is being optimized inside this algorithm?
 Finally, a customer might evaluate this hypothesis on their data, which we have never seen during training or validation, as
 
 $$
-\mathcal{E}^\text{test} = \mathcal{E}(\Theta^*, \mathcal{L}_{01}, \cal D^\text{test})
+\mathcal{E}^\text{test} = \mathcal{E}(\Theta^*, \mathcal{L}_{01}, \mathcal{D}^\text{test})
 $$
 
 The customer just wants to buy the right stocks! So we use the real $\mathcal{L}_{01}$ here for validation.

--- a/reinforcement_learning.qmd
+++ b/reinforcement_learning.qmd
@@ -3,7 +3,7 @@
 *Reinforcement learning* (RL) is a type of machine learning where an agent learns to make decisions by interacting with an environment. Unlike other learning paradigms, RL has several distinctive characteristics:
 
 - The agent interacts directly with an environment, receiving feedback in the form of rewards or penalties
-- The agent can choose actions that influences what information it gains from the environment
+- The agent can choose actions that influence what information it gains from the environment
 - The agent updates its decision-making strategy incrementally as it gains more experience
 
 In a reinforcement learning problem, the interaction between the agent and environment follows a specific pattern:
@@ -33,7 +33,7 @@ The interaction cycle proceeds as follows:
 6. Agent receives a new *reward* $r^{(i+1)}$
 7. This cycle continues...
 
-Similar to MDP @sec-mdps, in an RL problem, the agent's goal is to learn a *policy* - a mapping from states to actions - that maximizes its expected cumulative reward over time. This policy guides the agent's decision-making process, helping it choose actions that lead to the most favorable outcomes.
+Similar to MDPs (@sec-mdps), in an RL problem, the agent's goal is to learn a *policy* - a mapping from states to actions - that maximizes its expected cumulative reward over time. This policy guides the agent's decision-making process, helping it choose actions that lead to the most favorable outcomes.
 
 
 
@@ -47,7 +47,7 @@ Similar to MDP @sec-mdps, in an RL problem, the agent's goal is to learn a *poli
 
 <!-- Most of the focus is on the first criterion (which is called “sample efficiency”), because the second one is very difficult. The first criterion is reasonable when the learning can take place somewhere safe (imagine a robot learning, inside the robot factory, where it can’t hurt itself too badly) or in a simulated environment. -->
 
-Approaches to reinforcement learning differ significantly according to what kind of hypothesis or model is being learned. Roughly speaking, RL methods can be categorized into model-free methods and model-based methods. The main distinction is that model-based methods explicitly learn the transition and reward models to assist the end-goal of learning a policy; model-free methods do not. We will start our discussion with the model-free methods, and introduce two of the arguably most popular types of algorithms, Q-learning @sec-q_learning and policy gradient @sec-rl_policy_search. We then describe model-based methods @sec-rl_model_based. Finally, we briefly consider "bandit" problems @sec-bandit, which can be viewed as a simplified RL setting with no state transitions (or a trivial one-state MDP), where the main issue is exploration versus exploitation across actions.
+Approaches to reinforcement learning differ significantly according to what kind of hypothesis or model is being learned. Roughly speaking, RL methods can be categorized into model-free methods and model-based methods. The main distinction is that model-based methods explicitly learn the transition and reward models to assist the end-goal of learning a policy; model-free methods do not. We will start our discussion with the model-free methods, and introduce two of the arguably most popular types of algorithms, Q-learning (@sec-q_learning) and policy gradient (@sec-rl_policy_search). We then describe model-based methods (@sec-rl_model_based). Finally, we briefly consider "bandit" problems (@sec-bandit), which can be viewed as a simplified RL setting with no state transitions (or a trivial one-state MDP), where the main issue is exploration versus exploitation across actions.
 
 ### Model-free methods
 
@@ -60,9 +60,7 @@ Q-learning is a frequently used class of RL algorithms that concentrates on lear
 
 
 $$
-\begin{equation}
   \mathrm{Q}(s,a) = \mathrm{R}(s,a) + \gamma \sum_{s'} \mathrm{T}(s,a,s')\max_{a'}\mathrm{Q}(s',a')
-\end{equation}
 $$
 
 ::: {.column-margin}
@@ -131,10 +129,8 @@ numbers. There are many Q-learning extensions that handle large or continuous st
 In the Q-learning update rule
 
 $$
-\begin{equation}\label{q_avg}
   \mathrm{Q}[s, a] \leftarrow (1-\alpha)\mathrm{Q}[s, a]
   + \alpha(r + \gamma \max_{a'}\mathrm{Q}[s',a'])
-\end{equation}
 $${#eq-q-avg}
 
 the term $(r + \gamma \max_{a'}\mathrm{Q}[s',a'])$ is often referred to as the one-step look-ahead *target*. The update can be viewed as a
@@ -146,10 +142,8 @@ running average with a learning rate $\alpha.$
 @eq-q-avg can also be equivalently rewritten as
 
 $$
-\begin{equation}\label{td:q}
   \mathrm{Q}[s, a] \leftarrow \mathrm{Q}[s, a]
   + \alpha\bigl((r + \gamma \max_{a'} \mathrm{Q}[s',a'])-\mathrm{Q}[s,a]\bigr),
-\end{equation}
 $${#eq-td-q}
 
 which allows us to interpret Q-learning in yet another way: we make an update (or correction) based on the temporal difference between the target and the current estimated value $\mathrm{Q}[s, a].$
@@ -165,13 +159,13 @@ But, during learning, the $\mathrm{Q}$ value estimates won't be very
 good and exploration is important.  However, exploring completely at random is also usually not the best strategy while learning, because it is good to focus your attention on the parts of the state space
 that are likely to be visited when executing a good policy (not a bad or random one).
 
-A typical action-selection strategy that attempts to address this *exploration versus exploitation* dilemma is the so-called *$\epsilon$-greedy* strategy:
+A typical action-selection strategy that attempts to address this *exploration versus exploitation* dilemma is the so-called *$\varepsilon$-greedy* strategy:
 
-- with probability $1-\epsilon$, choose $\arg\max_{a \in \mathcal{A}} \mathrm{Q}(s,a)$;
+- with probability $1-\varepsilon$, choose $\arg\max_{a \in \mathcal{A}} \mathrm{Q}(s,a)$;
 
-- with probability $\epsilon$, choose the action $a \in \mathcal{A}$ uniformly at random.
+- with probability $\varepsilon$, choose the action $a \in \mathcal{A}$ uniformly at random.
 
-where the $\epsilon$ probability of choosing a random action helps the agent to explore and try out actions that might not seem so desirable at the moment.
+where the $\varepsilon$ probability of choosing a random action helps the agent to explore and try out actions that might not seem so desirable at the moment.
 
 Q-learning has the surprising property that under some standard assumptions, it is *guaranteed* to converge to the actual optimal $\mathrm{Q}$ function! The conditions it needs to satisfy are: having a finite state-action space, visiting every state-action pair infinitely often, and the learning rate $\alpha$ must satisfy a scheduling condition. This implies that for exploration strategy specifically, any strategy is okay as long as it tries every state-action infinitely often on an infinite run (so that it doesn't converge prematurely to a bad action choice).
 
@@ -211,7 +205,7 @@ Q-learning is guaranteed to converge to the optimal Q function under weak condit
 
 The first time the robot moves to the right and goes down the hallway,
 it will update the $\mathrm{Q}$ value just for state 9 on the hallway and
-action ``right'' to have a high value, but it won't yet understand
+action "right" to have a high value, but it won't yet understand
 that moving to the right in the earlier steps was a good choice. The
 next time it moves down the hallway it updates the value of the state before the last one, and so on.  After 10 trips down the hallway, it now can see that it is better to move to the right than to the left.
 
@@ -233,7 +227,7 @@ $$
 $$
 
 ::: {.column-margin}
-We are violating our usual notational conventions here, and writing $\mathrm{Q}^{i}$ to mean the Q value function that results after the robot runs all the way to the end of the hallway, when executing the policy that always moves to the right.
+We are violating our usual notational conventions here, and writing $\mathrm{Q}^{(i)}$ to mean the Q values after the robot's $i$-th trip down the hallway, executing the policy that always moves right.
 :::
 
 Since the only nonzero reward from moving right is $\mathrm{R}(9,\text{right}) = 1000$, after our robot makes it down the hallway once, our new Q vector is
@@ -282,9 +276,9 @@ $$
 
 $$
 \mathrm{Q}^{(10)}(i = 0, \ldots, 9;\,\text{right})
-=\\
+=
 \begin{bmatrix}
-387.4 & 420.5 & 478.3 & 531.4 & 590.5 & 656.1 & 729 & 810 & 900 & 1000
+387.4 & 430.5 & 478.3 & 531.4 & 590.5 & 656.1 & 729 & 810 & 900 & 1000
 \end{bmatrix}\,,
 $$
 
@@ -313,7 +307,7 @@ y \;=\; r + \gamma \max_{a'} Q_\theta(s', a')
 $$
 
 :::{.column-margin}
-This is the so-called squared Bellman error; as the name suggests, it's closely related to the Bellman equation we saw in **MDPs** in @sec-mdps. Roughly speaking, this error measures how much the Bellman equality is violated.
+This is the so-called squared Bellman error; as the name suggests, it's closely related to the Bellman equation we saw in **MDPs** (@sec-mdps). Roughly speaking, this error measures how much the Bellman equality is violated.
 :::
 
 An important subtlety: the target $y$ also depends on $\theta$ (through $Q_\theta(s', a')$), but we treat it as a constant when computing the gradient. The fitted-Q algorithm below makes this explicit by freezing the target as a regression label.
@@ -338,7 +332,7 @@ One form of instability that we do know how to guard against is *catastrophic fo
 And, in fact, we routinely shuffle their order in the data file, anyway.
 :::
 
-But when a learning agent, such as a robot, is moving through an environment, the sequence of states it encounters will be temporally correlated. For example, the robot might spend 12 hours in a dark environment and then 12 in a light one. This can mean that while it is in the dark, the neural-network weight-updates will make $Q_\theta$ \"forget\" the value function for when it's light.
+But when a learning agent, such as a robot, is moving through an environment, the sequence of states it encounters will be temporally correlated. For example, the robot might spend 12 hours in a dark environment and then 12 in a light one. This can mean that while it is in the dark, the neural-network weight-updates will make $Q_\theta$ "forget" the value function for when it's light.
 
 One way to handle this is to use *experience replay*, where we save our $(s,a,s',r)$ experiences in a *replay buffer*. Whenever we take a step in the world, we add the $(s,a,s',r)$ to the replay buffer and use it to do a Q-learning update. Then we also randomly select some number of tuples from the replay buffer, and do Q-learning updates based on them as well. In general, it may help to keep a *sliding window* of just the 1000 most recent experiences in the replay buffer. (A larger buffer will be necessary for situations when the optimal policy might visit a large part of the state space, but we like to keep the buffer size small for memory reasons and also so that we don't focus on parts of the state space that are irrelevant for the optimal policy.) The idea is that it will help us propagate reward values through our state space more efficiently if we do these updates. We can see it as doing something like value iteration, but using samples of experience rather than a known model.
 
@@ -364,12 +358,12 @@ called *fitted Q*. It uses the same Bellman-error idea as above, but cleanly sep
 
 \begin{algorithm}
 \begin{algorithmic}[1]
-  \Procedure{Fitted-Q-Learning}{$\mathcal{A}, s_0, \gamma, \epsilon, m$}
+  \Procedure{Fitted-Q-Learning}{$\mathcal{A}, s_0, \gamma, \varepsilon, m$}
     \State $s \gets s_0$ \Comment{e.g., $s_0$ can be drawn randomly from $\mathcal{S}$}
     \State $\mathcal{D} \gets \emptyset$
     \State initialize neural-network representation of $Q$
     \While{True}
-      \State $\mathcal{D}_\text{new} \gets$ experience from executing $\epsilon$-greedy policy based on $Q$ for $m$ steps
+      \State $\mathcal{D}_\text{new} \gets$ experience from executing $\varepsilon$-greedy policy based on $Q$ for $m$ steps
       \State $\mathcal{D} \gets \mathcal{D} \cup \mathcal{D}_\text{new}$ represented as tuples $(s, a, s', r)$
       \State $\mathcal{D}_\text{supervised} \gets \emptyset$
       \For{each tuple $(s, a, s', r) \in \mathcal{D}$}
@@ -408,7 +402,7 @@ Our goal is to choose $\theta$ to maximize the expected cumulative reward $J(\th
 $$
 J(\theta) = \mathbb{E}\left[\sum_{t=0}^{\infty}\gamma^t R_t \,\middle|\, a_t \sim \pi_\theta(\cdot \mid S_t)\right],
 $$
-which we maximize by gradient ascent: $\theta \leftarrow \theta + \alpha \nabla_\theta J(\theta)$, with learning rate $\alpha > 0$.
+which we maximize by gradient ascent: $\theta \leftarrow \theta + \eta \nabla_\theta J(\theta)$, with learning rate $\eta > 0$.
 
 To run gradient ascent we need an estimate of $\nabla_\theta J(\theta)$. The classic approach is *REINFORCE*, which estimates the gradient from sampled trajectories by increasing the probability of actions that led to high return and decreasing the probability of actions that led to low return. These methods can work well, but they are often noisy and difficult to tune in practice.
 
@@ -439,7 +433,7 @@ Bandit problems are a subset of reinforcement learning problems. A basic bandit 
 - A probabilistic reward function $R_p: \mathcal{A} \times \mathcal{R} \rightarrow \mathbb{R}$, i.e., $R_p$ is a function that takes an action and a reward and returns the probability of getting that reward conditioned on that action being taken, $R_p(a, r) = Pr(\text{reward} = r \mid \text{action} = a)$. Each time the agent takes an action, a new value is drawn from this distribution.
 
 :::{.column-margin}
-Notice that this probablistic rewards set up in bandits differs from the "rewards are deterministic" assumptions we made so far.
+Notice that this probabilistic reward setup in bandits differs from the "rewards are deterministic" assumption we made so far.
 :::
 
 
@@ -458,7 +452,7 @@ The theory ultimately tells us that, the longer our horizon $h$ (or similarly, c
 
 Bandit problems are reinforcement learning problems (and very different from batch supervised learning) in that:
 
-- The agent gets to influence what data it obtains (selecting $a$ gives it another sample from $R(a, r)$), and
+- The agent gets to influence what data it obtains (selecting $a$ gives it another sample from $R_p(a, r)$), and
 - The agent is penalized for mistakes it makes while it is learning (trying to maximize the expected reward it gets while behaving).
 
 In a *contextual bandit problem*, you have multiple possible states from some set $\mathcal{S}$, and a separate bandit problem associated with each one.


### PR DESCRIPTION
Part of a chapter-by-chapter polish pass.

Reinforcement learning:
- Fix numerical error in the hallway example: Q^(10) entry 420.5 -> 430.5 (0.9^8 x 1000; neighboring entries confirm the pattern)
- Remove stale \begin{equation}\label{...} wrappers inside $$ displays and an invalid bare \\ line break (breaks PDF rendering)
- epsilon -> varepsilon for epsilon-greedy per the notation guide; policy-gradient step uses eta (alpha is reserved for the Q-learning rate)
- Literal backtick quotes, margin-note wording, assorted grammar

Matrix calculus appendix:
- Fix wrong "same shape" claim for x^T A identity (x is n x 1, A is n x m)
- Fix (a,b) vs (a,c) index mismatch in the Einstein-summation section and a missing partial symbol
- eqnarray-style &=& inside aligned -> &=; raw || norms -> \lVert \rVert; typos

NN appendix:
- Margin note: the "adadelta" variant shown (fixed eta, EMA of squared gradients) is usually called RMSProp
- Adam parameters B_1/B_2 -> beta_1/beta_2; batch-norm section loss L -> script L; fix ignored {scale=0.7} image attribute

Nutshell:
- Convert broken \(...\) math delimiters (rendered as literal "(X)" in HTML) and fix the collapsed "Given:" list
- Remove a fully duplicated paragraph + equation (one copy had broken "$ \lambda $" math)
- Fix OCR artifacts (A_in -> A_2, L01(g,h) -> L01(g,y), D^tot -> D^test, \text spacing); standardize on script X/Y spaces and D^val; validation calls take D per V's definition

Verified: full `quarto render` passes; nutshell.html renders the math and list correctly.