### PR TITLE
Add DEV.md; make README reader-facing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# 6.390 course notes (Quarto book)
+
+- Dev setup, commands, and layout: see `DEV.md`. Renders need TeX; if `latex: command not found`, run `export PATH="/Library/TeX/texbin:$PATH"` first.
+- Math notation rules live in `NOTATION.md`; follow them in any edit (word subscripts in `\text{}`, upright MDP letters, `\lVert \rVert` norms).
+- Pseudocode `#| label:` values must not start with `alg-`; that prefix crashes Quarto's crossref filter. Use plain names (`Q-Learning`).
+- Margin notes are `::: {.column-margin}`; do not invent other class names.
+- Run a full `quarto render` and check for errors before opening a PR. Merging to `main` auto-deploys the live site.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# 6.390 course notes (Quarto book)
-
-- Dev setup, commands, and layout: see `DEV.md`. Renders need TeX; if `latex: command not found`, run `export PATH="/Library/TeX/texbin:$PATH"` first.
-- Math notation rules live in `NOTATION.md`; follow them in any edit (word subscripts in `\text{}`, upright MDP letters, `\lVert \rVert` norms).
-- Pseudocode `#| label:` values must not start with `alg-`; that prefix crashes Quarto's crossref filter. Use plain names (`Q-Learning`).
-- Margin notes are `::: {.column-margin}`; do not invent other class names.
-- Run a full `quarto render` and check for errors before opening a PR. Merging to `main` auto-deploys the live site.
+Read `DEV.md` before building or editing; it has the TeX PATH fix renders need, the repo layout, and the conventions that break renders. Math notation rules are in `NOTATION.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-Read `DEV.md` before building or editing; it has the TeX PATH fix renders need, the repo layout, and the conventions that break renders. Math notation rules are in `NOTATION.md`.

--- a/DEV.md
+++ b/DEV.md
@@ -23,7 +23,7 @@ Run a full `quarto render` before opening a PR; some errors (crossref problems, 
 ## Repo layout
 
 - Chapter sources are the root `*.qmd` files, in the order listed under `chapters:` in `_quarto.yml`. Appendices are listed under `appendices:`.
-- `NOTATION.md` is the course-wide notation and style guide. Follow it for any math edits.
+- `NOTATION.md` is the course-wide notation and style guide. Follow it for any math edits; the rules most often violated are word subscripts in `\text{}` (`\mathcal{D}_{\text{train}}`, not `\mathcal{D}_{train}`), upright `\mathrm{R}, \mathrm{T}, \mathrm{V}, \mathrm{Q}` for MDP functions, and `\lVert \cdot \rVert` for norms (never raw `||`).
 - `figures/` holds chapter images; `logo/` the site assets; `_extensions/` the Quarto filters (`pseudocode`, `imagify`).
 - `style.css`, `ga.html`, and `pre-title.html` are site chrome wired up in `_quarto.yml` and `index.qmd`.
 

--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,38 @@
+# Developing locally
+
+## Prerequisites
+
+1. **Quarto CLI**. Install from [quarto.org](https://quarto.org/docs/get-started/); the step-one CLI download is enough. Check with `quarto --version`.
+2. **A TeX distribution** (MacTeX on macOS, TeX Live elsewhere). The tikz figures in the notes compile through the `imagify` filter, which shells out to `latex` and `dvisvgm`. Both must be on your PATH.
+
+If a render fails with `sh: latex: command not found`, TeX is installed but not on the PATH of the shell running Quarto. On macOS:
+
+```sh
+export PATH="/Library/TeX/texbin:$PATH"
+```
+
+## Preview and render
+
+```sh
+quarto preview   # live-reload server at localhost:8888
+quarto render    # full build into _book/
+```
+
+Run a full `quarto render` before opening a PR; some errors (crossref problems, LaTeX failures in tikz blocks) only show up on a full build.
+
+## Repo layout
+
+- Chapter sources are the root `*.qmd` files, in the order listed under `chapters:` in `_quarto.yml`. Appendices are listed under `appendices:`.
+- `NOTATION.md` is the course-wide notation and style guide. Follow it for any math edits.
+- `figures/` holds chapter images; `logo/` the site assets; `_extensions/` the Quarto filters (`pseudocode`, `imagify`).
+- `style.css`, `ga.html`, and `pre-title.html` are site chrome wired up in `_quarto.yml` and `index.qmd`.
+
+## Conventions that will bite you
+
+- Pseudocode blocks take a `#| label:` cell option so algorithms number correctly, but the label must not start with `alg-`. That prefix collides with the custom `alg` crossref type in `_quarto.yml` and crashes the render. Plain names like `Q-Learning` work.
+- Margin notes use `::: {.column-margin}`. Other class names render as unstyled divs.
+- Avoid referring to pseudocode line numbers in prose. The HTML and PDF renderers number `\Procedure` lines differently, so refer to steps by content.
+
+## Deploying
+
+Merging to `main` triggers a webhook that rebuilds and publishes the live site at [introml.mit.edu/notes](https://introml.mit.edu/notes/). No manual deploy step.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+# License
+
+Copyright Massachusetts Institute of Technology.
+
+Copyright 6.390 (formerly 6.036) Intro to Machine Learning course staff.
+
+These course notes are licensed under the [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License (CC BY-NC-SA 4.0)](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+
+You are free to share and adapt this material for non-commercial purposes, provided you give appropriate credit and distribute any derivatives under the same license. See the [full legal code](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode) for the complete terms.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Source for the MIT 6.390 course notes, published at [introml.mit.edu/notes](http
 The notes are a [Quarto](https://quarto.org) book. Chapter sources are the `*.qmd` files at the repo root, in the order listed in `_quarto.yml`; `NOTATION.md` is the course-wide notation guide.
 
 To build and preview locally, see [DEV.md](DEV.md). Merging to `main` publishes the live site.
+
+Licensed under [CC BY-NC-SA 4.0](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -1,15 +1,7 @@
-# How to give this a spin?
+# 6.390 Intro to Machine Learning, Course Notes
 
-Preview your changes locally (see below). When you're happy, push to `main`. This will update the live site at https://introml.mit.edu/notes/
+Source for the MIT 6.390 course notes, published at [introml.mit.edu/notes](https://introml.mit.edu/notes/).
 
+The notes are a [Quarto](https://quarto.org) book. Chapter sources are the `*.qmd` files at the repo root, in the order listed in `_quarto.yml`; `NOTATION.md` is the course-wide notation guide.
 
-
-# How to dev locally?
-
-We need two things.
-
-1. The engine [`quarto`](https://quarto.org/docs/get-started/). We just need that page's step-one `CLI` download. It should be a simple `curl` or `wget` command on the terminal. Or on MacOS, just a download and one-click installation. If the installation goes right, the executable `quarto` should be callable from the terminal.
-
-2. Clone this repo. In the terminal, `cd` into the root of this repo. Run `quarto preview`. If all goes well, a `localhost:8888` link will pop up, and a browser tab will open. That tab will be "live": i.e. it'd be updated as we make local changes. 
-
-In terms of content, book chapter source files are those `*.qmd` files. The `qmd` syntax is almost identical to `markdown` (which itself is pretty close to LaTeX). The `qmd` files are converted to `html` by `quarto` and then served on the website. 
+To build and preview locally, see [DEV.md](DEV.md). Merging to `main` publishes the live site.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -45,7 +45,10 @@ book:
       - text: Accessibility
         href: https://accessibility.mit.edu/
         icon: universal-access
-  # page-footer:
+  page-footer:
+    center: |
+      © MIT and the 6.390 (formerly 6.036) course staff.
+      Licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
   page-navigation: true
 
 # bibliography:


### PR DESCRIPTION
Follow-up to the TeX-not-on-PATH render failure, plus licensing.

- `DEV.md`: prerequisites (Quarto CLI + TeX distribution; imagify shells out to `latex`/`dvisvgm`), the `sh: latex: command not found` fix, preview/render commands, repo layout with the most-violated NOTATION.md rules, and render-breaking conventions (no `alg-` pseudocode label prefix, `.column-margin` only, no hard-coded pseudocode line numbers in prose)
- `README.md`: now reader-facing (title, live-site link, layout one-liner, links to DEV.md and LICENSE.md)
- `LICENSE.md`: CC BY-NC-SA 4.0, copyright MIT and the 6.390 (formerly 6.036) course staff