### PR TITLE
Pin sidebar license notice to the bottom of the bar

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -12,3 +12,12 @@
 .study-question-callout .icon {
     color: #007BFF; /* Change icon color */
 }
+/* Pin the license notice to the bottom of the sidebar */
+#quarto-sidebar {
+  display: flex;
+  flex-direction: column;
+}
+#quarto-sidebar .quarto-sidebar-footer {
+  margin-top: auto;
+  padding-bottom: 0.75rem;
+}


### PR DESCRIPTION
Re-lands the CSS commit stranded when #76 merged mid-push (same race as #70): flex column on #quarto-sidebar plus margin-top: auto on the footer, so the license sits at the sidebar's bottom edge instead of floating under the chapter list. This is the placement verified in the local preview.