### PR TITLE
Fix f_1 convolution result in the 2D filter-bank figure 

### DIFF
--- a/convolutional_neural_networks.qmd
+++ b/convolutional_neural_networks.qmd
@@ -309,8 +309,8 @@ Both slices of the tensor filter are identical here, so the output is simply the
     \node at (0.5,1.5) {0}; \node at (1.5,1.5) {0}; \node at (2.5,1.5) {0}; \node at (3.5,1.5) {2}; \node at (4.5,1.5) {0}; \node at (5.5,1.5) {0};
     \node at (0.5,2.5) {1}; \node at (1.5,2.5) {1}; \node at (2.5,2.5) {1}; \node at (3.5,2.5) {3}; \node at (4.5,2.5) {1}; \node at (5.5,2.5) {1};
     \node at (0.5,3.5) {1}; \node at (1.5,3.5) {1}; \node at (2.5,3.5) {1}; \node at (3.5,3.5) {3}; \node at (4.5,3.5) {1}; \node at (5.5,3.5) {1};
-    \node at (0.5,4.5) {1}; \node at (1.5,4.5) {1}; \node at (2.5,4.5) {1}; \node at (3.5,4.5) {2}; \node at (4.5,4.5) {1}; \node at (5.5,4.5) {1};
-    \node at (0.5,5.5) {0}; \node at (1.5,5.5) {0}; \node at (2.5,5.5) {0}; \node at (3.5,5.5) {1}; \node at (4.5,5.5) {0}; \node at (5.5,5.5) {0};
+    \node at (0.5,4.5) {1}; \node at (1.5,4.5) {1}; \node at (2.5,4.5) {1}; \node at (3.5,4.5) {3}; \node at (4.5,4.5) {1}; \node at (5.5,4.5) {1};
+    \node at (0.5,5.5) {0}; \node at (1.5,5.5) {0}; \node at (2.5,5.5) {0}; \node at (3.5,5.5) {2}; \node at (4.5,5.5) {0}; \node at (5.5,5.5) {0};
   \end{scope}
 
   % === ARROWS FROM RESULTS TO TENSOR FILTER ===
@@ -349,8 +349,8 @@ Both slices of the tensor filter are identical here, so the output is simply the
     \node at (0.5,1.5) {0}; \node at (1.5,1.5) {0}; \node at (2.5,1.5) {1}; \node at (3.5,1.5) {3}; \node at (4.5,1.5) {1}; \node at (5.5,1.5) {0};
     \node at (0.5,2.5) {1}; \node at (1.5,2.5) {1}; \node at (2.5,2.5) {2}; \node at (3.5,2.5) {4}; \node at (4.5,2.5) {2}; \node at (5.5,2.5) {1};
     \node at (0.5,3.5) {3}; \node at (1.5,3.5) {4}; \node at (2.5,3.5) {4}; \node at (3.5,3.5) {6}; \node at (4.5,3.5) {4}; \node at (5.5,3.5) {3};
-    \node at (0.5,4.5) {1}; \node at (1.5,4.5) {1}; \node at (2.5,4.5) {2}; \node at (3.5,4.5) {3}; \node at (4.5,4.5) {2}; \node at (5.5,4.5) {1};
-    \node at (0.5,5.5) {0}; \node at (1.5,5.5) {0}; \node at (2.5,5.5) {1}; \node at (3.5,5.5) {2}; \node at (4.5,5.5) {1}; \node at (5.5,5.5) {0};
+    \node at (0.5,4.5) {1}; \node at (1.5,4.5) {1}; \node at (2.5,4.5) {2}; \node at (3.5,4.5) {4}; \node at (4.5,4.5) {2}; \node at (5.5,4.5) {1};
+    \node at (0.5,5.5) {0}; \node at (1.5,5.5) {0}; \node at (2.5,5.5) {1}; \node at (3.5,5.5) {3}; \node at (4.5,5.5) {1}; \node at (5.5,5.5) {0};
   \end{scope}
 \end{tikzpicture}
 :::


### PR DESCRIPTION
The input cross has its vertical bar spanning rows 1-5, but the f_1 (vertical detector) result grid was computed as if the bar spanned rows 1-4, making the top two entries of its center column one too small. Corrected those two cells and the two cells they feed in the final output, which is the sum of the two channels.
fixes #80 