### PR TITLE
Wrap the 2D convolution animation in a raw HTML block

### DIFF
--- a/figures/cnn_2d_conv_anim.html
+++ b/figures/cnn_2d_conv_anim.html
@@ -1,3 +1,6 @@
+```{=html}
+<!-- Raw HTML block: pandoc must not parse the indented markup below
+     as markdown, which would turn the control bar into a code block. -->
 <div class="c2d-wrap" id="c2d-conv">
   <svg class="c2d-svg" viewBox="-1.3 -11 39.1 17.4" role="img"
        aria-label="Animation of a two-filter bank. A 3 by 3 window slides over the 6 by 6 padded input, filling one cell of each of the two channels at a time; then a tensor filter slides over both channels together, filling the final output.">
@@ -285,3 +288,4 @@ body.quarto-dark .c2d-wrap{ --c2d-f2:#f0a355; --c2d-f1:#7fb0f5; --c2d-hl:#f2cd4a
   render(0);
 })();
 </script>
+```


### PR DESCRIPTION
Fixes the control-bar rendering reported on #83: the Play button, the step arrows, the slider, and the status span print as source text in a code block instead of rendering as controls.

## Cause

Pandoc parses the contents of an HTML block as markdown. The control-bar children are indented four spaces inside `<div class="c2d-bar">`, and four-space indentation starts an indented code block, so that markup is escaped and emitted as a `<pre>`. The `<svg>`, `<style>`, and `<script>` are unaffected, which is why the diagram itself draws correctly and only the controls break.

Wrapping the file in a `{=html}` raw block passes the markup through verbatim, so indentation inside it no longer matters.

## Why it did not show up in a local render

The behavior is Quarto-version dependent. The server renders with 1.6.39 and escapes the controls; a local 1.8.21 render does not. Confirmed by fetching the live page (3 escaped `&lt;button`, 0 real) against a local render (3 real, 0 escaped). A raw block is passthrough by definition, so it is correct on both.

## Verification

- Reproduced the mechanism directly with `pandoc -f markdown+markdown_in_html_blocks`: the current markup yields an escaped code block, the fenced version yields none.
- Re-rendered the chapter: 3 real `<button>` elements, 1 `<input class="c2d-range">`, 0 escaped, script intact.
- Drove the rendered book page headlessly to the final frame and confirmed the controls render and the diagram still matches the static figure cell for cell.

Independent of #84; the two touch different files and can merge in either order.
