### PR TITLE
Break the sidebar license notice into two short lines

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -46,8 +46,8 @@ book:
         href: https://accessibility.mit.edu/
         icon: universal-access
     footer: |
-      <small>© MIT and the 6.390 (formerly 6.036) course staff.
-      Licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).</small>
+      [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)<br>
+      &copy; MIT 6.390 (formerly 6.036) staff
   page-navigation: true
 
 # bibliography:

--- a/assets/style.css
+++ b/assets/style.css
@@ -20,4 +20,11 @@
 #quarto-sidebar .quarto-sidebar-footer {
   margin-top: auto;
   padding-bottom: 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  text-align: left;
+  text-wrap: balance;
+}
+#quarto-sidebar .quarto-sidebar-footer p {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
The license line in the sidebar footer wrapped mid-phrase. This gives it a deliberate two-line shape, mirroring the footer on https://shenshen.mit.edu/agencyai/.

- `_quarto.yml`: the link text is the short license name, `CC BY-NC-SA 4.0`, with an explicit `<br>` before the copyright line.
- `assets/style.css`: footer text at `0.75rem` with `line-height: 1.5`, and `margin-bottom: 0` on the inner `<p>`.

Checked in a headless Chromium render of `_book/index.html` at 1440px wide: each line fits without wrapping, the second measuring about 178px in the roughly 215px sidebar column.

Accessibility stays as the `universal-access` tool icon under the sidebar title rather than moving into the footer.