### PR TITLE
Write the squared loss as L(g, y) in the regression chapter

### DIFF
--- a/regression.qmd
+++ b/regression.qmd
@@ -41,7 +41,7 @@ What makes a hypothesis useful? That it works well on *new* data—that is, it m
 
 However, we don't know exactly what data this hypothesis might be tested on in the real world. So, we must *assume* a connection between the training data and testing data. Typically, the assumption is that they are drawn independently from the same probability distribution.
 
-To make this discussion more concrete, we need a *loss function* to express how unhappy we are when we guess an output $g = h(x)$ given an input $x$ for which the desired output was $a = y$.
+To make this discussion more concrete, we need a *loss function* to express how unhappy we are when we guess an output $g = h(x)$ given an input $x$ for which the desired output was $y$.
 
 
 Given a training set $\mathcal{D}_\text{train}$ and a hypothesis $h$ with parameters $\Theta$ (where $\Theta$ stands for all the parameters in our model), the *training error* of $h$ can be defined as the average loss on the training data:
@@ -118,9 +118,9 @@ where the model parameters are $\Theta = (\theta, \theta_0)$. In one dimension (
  
 For now, our objective in linear regression is to find a hypothesis that goes as close as possible, on average, to all of our training data. We define a *loss function* to describe how to evaluate the quality of the predictions our hypothesis is making, when compared to the "target" $y$ values in the data set. The choice of loss function is part of modeling your domain. In the absence of additional information about a regression problem, we typically use *squared loss*: 
 $$
-\mathcal{L}(g, a) = (g - a)^2\;\;,
+\mathcal{L}(g, y) = (g - y)^2\;\;,
 $$
-where $g=h(x)$ is our "guess" from the hypothesis, or the hypothesis' prediction, and $a$ is the "actual" observation (in other words, here $a$ is being used interchangeably with $y$). With this choice of squared loss, the average loss as generally defined in @eq-erm will become the so-called *mean squared error (MSE)*.
+where $g=h(x)$ is our "guess" from the hypothesis, or the hypothesis' prediction, and $y$ is the "actual" observation from the data set. With this choice of squared loss, the average loss as generally defined in @eq-erm will become the so-called *mean squared error (MSE)*.
 
 
 Applying the general optimization framework to the linear regression hypothesis class of @eq-linear_reg_hypothesis with squared loss and no regularization, our objective is to find values for $\Theta = (\theta, \theta_0)$ that minimize the MSE: 


### PR DESCRIPTION
Part of 390introml/fall26#2, option 1. The actual label is `y` everywhere and `a` is dropped as a label symbol. This is the week 2 slice, following #87.

`regression.qmd` line 44 introduced the desired output as `a = y`, line 121 wrote the squared loss as `\mathcal{L}(g, a) = (g - a)^2`, and line 123 explained that `a` was being used interchangeably with `y`. All three now use `y`, and the interchangeability aside is gone since there is nothing left to reconcile.

Left for a later PR: `classification.qmd` line 151 (week 4).

The matching site PR is 390introml/fall26#249.