### PR TITLE
Write the 0-1 loss as L(g, y) and add the symbolic NLL loss in the classification chapter

### DIFF
--- a/classification.qmd
+++ b/classification.qmd
@@ -148,8 +148,8 @@ Given a data set and the hypothesis class of linear classifiers, our goal will b
 
 For classification, it is natural to make predictions in $\{+1, 0\}$ and use the 0-1 loss function, $\mathcal{L}_{01}$, as introduced in @sec-intro: 
 
-$$\mathcal{L}_{01}(g, a) = \begin{cases}
-    0 & \text{if $g = a$} \\
+$$\mathcal{L}_{01}(g, y) = \begin{cases}
+    0 & \text{if $g = y$} \\
     1 & \text{otherwise}
   \end{cases} \; .
 $$ 
@@ -336,6 +336,11 @@ $$
   -\left(\text{actual}\cdot \log (\text{guess}) + (1 - \text{actual})\cdot\log (1 -
   \text{guess})\right) \;\;.
 $$ 
+
+In symbols, with $g$ for the guess and $y$ for the actual label, 
+$$
+\mathcal{L}_\text{nll}(g, y) = -\left(y \log g + (1 - y)\log(1 - g)\right) \;\;.
+$$
 
 This loss function is also sometimes referred to as the *log loss* or *cross entropy*.
 


### PR DESCRIPTION
Part of 390introml/fall26#2, option 1. The actual label is `y` everywhere and `a` is dropped as a label symbol. This is the week 4 slice, following #87 and #88.

`classification.qmd` line 151 wrote the 0-1 loss as `\mathcal{L}_{01}(g, a)`. It now reads `\mathcal{L}_{01}(g, y)`. That was the last symbolic use of `a` for the label in the notes.

Lines 335 to 338 write the NLL loss in words, `\mathcal{L}_\text{nll}(\text{guess}, \text{actual})`. That stays, and the same formula in `g` and `y` follows it, so the reader sees the letters that the objective a few lines above already uses.

One more PR follows for `neural_networks.qmd`, where the loss is also written in words (week 5).