### PR TITLE
State the label rule without enumerating the other meanings of a

### DIFF
--- a/NOTATION.md
+++ b/NOTATION.md
@@ -26,7 +26,7 @@ Consistent notation across all course materials: notes, exams, labs, homework, a
 
 ### Functions
 - **Hypothesis**: `h(x; \theta, \theta_0)` -- semicolon separates input from parameters
-- **Loss**: `\mathcal{L}(g, y)` for general loss (`g` = guess, `y` = actual label; never `a`, which is reserved for activations, actions, and learned representations); specific variants `\mathcal{L}_{\text{nll}}`, `\mathcal{L}_{\text{SE}}`
+- **Loss**: `\mathcal{L}(g, y)` for general loss (`g` = guess, `y` = actual label; never `a`, which is reserved for activations, actions, learned representations, and per-example weights); specific variants `\mathcal{L}_{\text{nll}}`, `\mathcal{L}_{\text{SE}}`
 - **Objective**: `J(\theta)` or `J(\theta, \theta_0)`
 - **Sigmoid**: `\sigma(z) = \frac{1}{1 + e^{-z}}`
 - **Softmax**: `\operatorname{softmax}`


### PR DESCRIPTION
Revises #87's parenthetical. That PR listed the non-label meanings of `a` as activations, actions, and learned representations. Enumerating them invites a longer list every time another meaning turns up, and the meanings are already defined where they belong, actions under MDPs and activations under Neural Networks.

Line 29 now reads `(`g` = guess, `y` = actual label, never `a`)`, which is the actual rule and shorter than what it replaces.

The companion site PR renames lab 4's per-example weights from $a^{(i)}$ to $w^{(i)}$, so nothing in the course still uses `a` for a per-example quantity.